### PR TITLE
feat: add API client and data ingestion (closes #3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       SUPABASE_JDBC_URL: ${SUPABASE_JDBC_URL}
       SUPABASE_DB_USER: ${SUPABASE_DB_USER}
       SUPABASE_DB_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      EXTERNAL_NEWS_API_URL: ${EXTERNAL_NEWS_API_URL:-https://newsapi.org/v2/top-headlines}
+      EXTERNAL_NEWS_API_KEY: ${EXTERNAL_NEWS_API_KEY:-}
+      INGESTION_INTERVAL_MS: ${INGESTION_INTERVAL_MS:-600000}
     env_file:
       - .env
     restart: unless-stopped

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,21 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- OkHttp MockWebServer – for unit-testing WebClient HTTP calls -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Reactor Test – StepVerifier for reactive streams -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -80,6 +95,15 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <!-- Surefire: enable Byte Buddy experimental mode so Mockito works on Java 25 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
+                </configuration>
             </plugin>
 
             <!-- JaCoCo for test coverage reporting -->

--- a/src/main/java/com/realnewsletter/client/ExternalNewsClient.java
+++ b/src/main/java/com/realnewsletter/client/ExternalNewsClient.java
@@ -1,0 +1,141 @@
+package com.realnewsletter.client;
+
+import com.realnewsletter.dto.ArticleDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * HTTP client responsible for fetching trending articles from the external
+ * news API (e.g. <a href="https://newsapi.org">NewsAPI</a>).
+ *
+ * <p>All network calls are non-blocking and return reactive types so that
+ * callers can compose further reactive pipelines without blocking threads.</p>
+ */
+@Service
+public class ExternalNewsClient {
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalNewsClient.class);
+
+    private final WebClient webClient;
+    private final String trendingApiUrl;
+    private final String apiKey;
+
+    /**
+     * Constructs the client with its dependencies injected via constructor.
+     *
+     * @param webClient      the shared WebClient bean configured with timeouts
+     * @param trendingApiUrl base URL of the trending-articles endpoint
+     * @param apiKey         API key; may be empty when running in test environments
+     */
+    public ExternalNewsClient(
+            WebClient webClient,
+            @Value("${external.news.api.url:https://newsapi.org/v2/top-headlines}") String trendingApiUrl,
+            @Value("${external.news.api.key:}") String apiKey) {
+        this.webClient = webClient;
+        this.trendingApiUrl = trendingApiUrl;
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * Fetches trending articles from the remote news API.
+     *
+     * <p>The API returns a JSON envelope of the form:
+     * <pre>{@code { "articles": [ { "url": "...", "title": "...", "content": "..." } ] }}</pre>
+     * The response is unwrapped and each article is emitted individually as an
+     * {@link ArticleDto}.</p>
+     *
+     * <p>Non-2xx HTTP responses are converted to exceptions via
+     * {@code onStatus()} so that callers and the reactive pipeline can handle
+     * errors uniformly.</p>
+     *
+     * @return a {@link Flux} emitting one {@link ArticleDto} per article
+     */
+    public Flux<ArticleDto> fetchTrendingArticles() {
+        log.debug("Fetching trending articles from {}", trendingApiUrl);
+
+        URI requestUri = UriComponentsBuilder.fromHttpUrl(trendingApiUrl)
+                .queryParam("apiKey", apiKey)
+                .build()
+                .toUri();
+
+        return webClient.get()
+                .uri(requestUri)
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        response -> {
+                            log.error("News API returned error status: {}", response.statusCode());
+                            return response.bodyToMono(String.class)
+                                    .flatMap(body -> Mono.error(
+                                            new ExternalNewsApiException(
+                                                    "News API error " + response.statusCode() + ": " + body)));
+                        })
+                .bodyToMono(NewsApiResponse.class)
+                .flatMapMany(response -> {
+                    List<ArticleDto> articles = response.getArticles();
+                    if (articles == null || articles.isEmpty()) {
+                        log.debug("News API returned no articles");
+                        return Flux.empty();
+                    }
+                    return Flux.fromIterable(articles);
+                });
+    }
+
+    // ── Inner response wrapper ────────────────────────────────────────────────
+
+    /**
+     * Jackson-compatible wrapper that models the top-level NewsAPI JSON response.
+     *
+     * <pre>{@code { "status": "ok", "totalResults": 5, "articles": [ … ] }}</pre>
+     */
+    public static class NewsApiResponse {
+
+        private String status;
+        private Integer totalResults;
+        private List<ArticleDto> articles;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public Integer getTotalResults() {
+            return totalResults;
+        }
+
+        public void setTotalResults(Integer totalResults) {
+            this.totalResults = totalResults;
+        }
+
+        public List<ArticleDto> getArticles() {
+            return articles;
+        }
+
+        public void setArticles(List<ArticleDto> articles) {
+            this.articles = articles;
+        }
+    }
+
+    /**
+     * Exception thrown when the external news API returns a non-2xx response.
+     */
+    public static class ExternalNewsApiException extends RuntimeException {
+
+        public ExternalNewsApiException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/realnewsletter/config/WebClientConfig.java
+++ b/src/main/java/com/realnewsletter/config/WebClientConfig.java
@@ -1,0 +1,45 @@
+package com.realnewsletter.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+/**
+ * Spring configuration class that provides a shared {@link WebClient} bean
+ * pre-configured with sensible connection and response timeouts.
+ *
+ * <p>Using a single shared bean avoids the overhead of creating a new HTTP
+ * connection pool per injection point and makes timeout behaviour easy to
+ * test and reason about in one place.</p>
+ */
+@Configuration
+public class WebClientConfig {
+
+    /**
+     * Creates a {@link WebClient} instance backed by a Reactor Netty
+     * {@link HttpClient} with:
+     * <ul>
+     *   <li>5-second TCP connection timeout</li>
+     *   <li>5-second response timeout (time to first byte)</li>
+     * </ul>
+     *
+     * @param builder the auto-configured {@link WebClient.Builder} injected by Spring Boot
+     * @return the shared WebClient bean
+     */
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(5));
+
+        return builder
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}
+

--- a/src/main/java/com/realnewsletter/dto/ArticleDto.java
+++ b/src/main/java/com/realnewsletter/dto/ArticleDto.java
@@ -1,0 +1,78 @@
+package com.realnewsletter.dto;
+
+import java.util.UUID;
+
+/**
+ * Data Transfer Object representing a single news article returned by the
+ * external news API.
+ *
+ * <p>Fields are intentionally nullable so that partial API responses do not
+ * cause deserialization failures; callers are responsible for validating
+ * required fields before persisting or processing an article.</p>
+ */
+public class ArticleDto {
+
+    /** Locally assigned identifier; may be {@code null} when the DTO is first created from API data. */
+    private UUID id;
+
+    /** Canonical URL of the article. */
+    private String url;
+
+    /** Human-readable headline of the article. */
+    private String title;
+
+    /** Full or truncated body text of the article. */
+    private String content;
+
+    /** No-arg constructor required by Jackson for deserialization. */
+    public ArticleDto() {
+    }
+
+    /**
+     * Convenience all-args constructor.
+     *
+     * @param id      article identifier
+     * @param url     article URL
+     * @param title   article headline
+     * @param content article body text
+     */
+    public ArticleDto(UUID id, String url, String title, String content) {
+        this.id = id;
+        this.url = url;
+        this.title = title;
+        this.content = content;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}
+

--- a/src/main/java/com/realnewsletter/service/IngestionService.java
+++ b/src/main/java/com/realnewsletter/service/IngestionService.java
@@ -1,0 +1,61 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.client.ExternalNewsClient;
+import com.realnewsletter.dto.ArticleDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service responsible for periodically fetching articles from the external
+ * news API and preparing them for downstream processing (persistence,
+ * summarisation, etc.).
+ *
+ * <p>In this initial implementation the ingested articles are only logged.
+ * Persistence will be wired in a subsequent issue.</p>
+ */
+@Service
+public class IngestionService {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestionService.class);
+
+    private final ExternalNewsClient externalNewsClient;
+
+    /**
+     * Constructs the service with its dependency injected via constructor.
+     *
+     * @param externalNewsClient client used to fetch trending articles
+     */
+    public IngestionService(ExternalNewsClient externalNewsClient) {
+        this.externalNewsClient = externalNewsClient;
+    }
+
+    /**
+     * Scheduled ingestion job that runs at a configurable fixed delay.
+     *
+     * <p>The delay defaults to 600,000 ms (10 minutes) and can be overridden
+     * via the {@code ingestion.interval.ms} application property.</p>
+     *
+     * <p>The method blocks the scheduler thread intentionally using
+     * {@code .block()} because Spring's {@code @Scheduled} infrastructure
+     * runs tasks on a dedicated thread pool that is separate from the Netty
+     * event-loop; blocking here does not affect the reactive HTTP layer.</p>
+     */
+    @Scheduled(fixedDelayString = "${ingestion.interval.ms:600000}")
+    public void ingestScheduled() {
+        log.info("Ingestion job started – fetching trending articles");
+
+        List<ArticleDto> articles = externalNewsClient.fetchTrendingArticles()
+                .collectList()
+                .block();
+
+        int count = articles == null ? 0 : articles.size();
+        log.info("Ingestion job completed – fetched {} article(s)", count);
+
+        // TODO (issue #4): persist articles to the database.
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,19 @@ spring:
   flyway:
     enabled: true
 
+# ---------------------------------------------------------------------------
+# External News API configuration
+# ---------------------------------------------------------------------------
+external:
+  news:
+    api:
+      url: ${EXTERNAL_NEWS_API_URL:https://newsapi.org/v2/top-headlines}
+      key: ${EXTERNAL_NEWS_API_KEY:}
+
+# ---------------------------------------------------------------------------
+# Ingestion scheduler configuration
+# ---------------------------------------------------------------------------
+ingestion:
+  interval:
+    ms: ${INGESTION_INTERVAL_MS:600000}
+

--- a/src/test/java/com/realnewsletter/client/ExternalNewsClientTest.java
+++ b/src/test/java/com/realnewsletter/client/ExternalNewsClientTest.java
@@ -1,0 +1,141 @@
+package com.realnewsletter.client;
+
+import com.realnewsletter.dto.ArticleDto;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ExternalNewsClient}.
+ *
+ * <p>A {@link MockWebServer} stands in for the real external API so that
+ * tests are fast, deterministic, and offline-capable.</p>
+ */
+class ExternalNewsClientTest {
+
+    private MockWebServer mockWebServer;
+    private ExternalNewsClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        String baseUrl = mockWebServer.url("/v2/top-headlines").toString();
+
+        WebClient webClient = WebClient.builder().build();
+        client = new ExternalNewsClient(webClient, baseUrl, "test-api-key");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void fetchTrendingArticles_returnsArticlesFromApi() {
+        // language=JSON
+        String responseBody = """
+                {
+                  "status": "ok",
+                  "totalResults": 2,
+                  "articles": [
+                    {
+                      "url": "https://example.com/article1",
+                      "title": "First Article",
+                      "content": "Content of first article"
+                    },
+                    {
+                      "url": "https://example.com/article2",
+                      "title": "Second Article",
+                      "content": "Content of second article"
+                    }
+                  ]
+                }
+                """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(responseBody)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        Flux<ArticleDto> result = client.fetchTrendingArticles();
+
+        StepVerifier.create(result)
+                .assertNext(article -> {
+                    assertThat(article.getUrl()).isEqualTo("https://example.com/article1");
+                    assertThat(article.getTitle()).isEqualTo("First Article");
+                    assertThat(article.getContent()).isEqualTo("Content of first article");
+                })
+                .assertNext(article -> {
+                    assertThat(article.getUrl()).isEqualTo("https://example.com/article2");
+                    assertThat(article.getTitle()).isEqualTo("Second Article");
+                    assertThat(article.getContent()).isEqualTo("Content of second article");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void fetchTrendingArticles_returnsEmptyFlux_whenNoArticles() {
+        // language=JSON
+        String responseBody = """
+                {
+                  "status": "ok",
+                  "totalResults": 0,
+                  "articles": []
+                }
+                """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(responseBody)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        Flux<ArticleDto> result = client.fetchTrendingArticles();
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+    @Test
+    void fetchTrendingArticles_throwsException_onErrorResponse() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .setBody("{\"message\": \"Unauthorized\"}")
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        Flux<ArticleDto> result = client.fetchTrendingArticles();
+
+        StepVerifier.create(result)
+                .expectErrorMatches(ex ->
+                        ex instanceof ExternalNewsClient.ExternalNewsApiException
+                                && ex.getMessage().contains("401"))
+                .verify();
+    }
+
+    @Test
+    void fetchTrendingArticles_throwsException_onServerError() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setBody("{\"message\": \"Internal Server Error\"}")
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        Flux<ArticleDto> result = client.fetchTrendingArticles();
+
+        StepVerifier.create(result)
+                .expectErrorMatches(ex ->
+                        ex instanceof ExternalNewsClient.ExternalNewsApiException
+                                && ex.getMessage().contains("500"))
+                .verify();
+    }
+}
+

--- a/src/test/java/com/realnewsletter/service/IngestionServiceTest.java
+++ b/src/test/java/com/realnewsletter/service/IngestionServiceTest.java
@@ -1,0 +1,82 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.client.ExternalNewsClient;
+import com.realnewsletter.dto.ArticleDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link IngestionService}.
+ *
+ * <p>{@link ExternalNewsClient} is mocked so that network access is not
+ * required and the scheduler logic can be verified in isolation.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class IngestionServiceTest {
+
+    @Mock
+    private ExternalNewsClient externalNewsClient;
+
+    @InjectMocks
+    private IngestionService ingestionService;
+
+    @Test
+    void ingestScheduled_callsFetchAndLogsCount_whenArticlesReturned() {
+        ArticleDto article1 = new ArticleDto(null, "https://example.com/1", "Title 1", "Content 1");
+        ArticleDto article2 = new ArticleDto(null, "https://example.com/2", "Title 2", "Content 2");
+
+        when(externalNewsClient.fetchTrendingArticles())
+                .thenReturn(Flux.just(article1, article2));
+
+        // Should not throw; logging is verified by absence of exception.
+        ingestionService.ingestScheduled();
+
+        verify(externalNewsClient, times(1)).fetchTrendingArticles();
+    }
+
+    @Test
+    void ingestScheduled_handlesEmptyArticleList_gracefully() {
+        when(externalNewsClient.fetchTrendingArticles())
+                .thenReturn(Flux.empty());
+
+        // Should not throw even when no articles are returned.
+        ingestionService.ingestScheduled();
+
+        verify(externalNewsClient, times(1)).fetchTrendingArticles();
+    }
+
+    @Test
+    void ingestScheduled_delegatesToExternalClient_onEachInvocation() {
+        when(externalNewsClient.fetchTrendingArticles())
+                .thenReturn(Flux.just(
+                        new ArticleDto(null, "https://example.com/3", "Title 3", "Content 3")));
+
+        ingestionService.ingestScheduled();
+        ingestionService.ingestScheduled();
+
+        // Verify the client is called once per invocation of ingestScheduled().
+        verify(externalNewsClient, times(2)).fetchTrendingArticles();
+    }
+
+    @Test
+    void ingestScheduled_doesNotThrow_whenClientReturnsError() {
+        when(externalNewsClient.fetchTrendingArticles())
+                .thenReturn(Flux.error(new ExternalNewsClient.ExternalNewsApiException("API error")));
+
+        // block() will throw; we expect the exception to propagate.
+        org.junit.jupiter.api.Assertions.assertThrows(
+                Exception.class,
+                () -> ingestionService.ingestScheduled());
+    }
+}
+


### PR DESCRIPTION
## Summary

Implements issue #3 — API Client & Data Ingestion.

### Changes Made

- **`WebClientConfig`** — `@Configuration` class exposing a shared `WebClient` bean with 5-second connect and response timeouts via Reactor Netty `HttpClient`
- **`ArticleDto`** — DTO with fields: `id` (UUID), `url`, `title`, `content`
- **`ExternalNewsClient`** — `@Service` that fetches trending articles from the NewsAPI using `WebClient`; configurable via `external.news.api.url` and `external.news.api.key`; non-2xx responses handled via `onStatus()`
- **`IngestionService`** — `@Service` with `@Scheduled(fixedDelayString = "${ingestion.interval.ms:600000}")` that calls the client, collects articles, and logs the count; persistence deferred to issue #4
- **`application.yml`** — added `external.news.api.*` and `ingestion.interval.ms` configuration properties
- **`pom.xml`** — added `okhttp3:mockwebserver`, `reactor-test`, and Maven Surefire `net.bytebuddy.experimental` JVM arg (required for Mockito on Java 25)
- **`docker-compose.yml`** — added `EXTERNAL_NEWS_API_URL`, `EXTERNAL_NEWS_API_KEY`, and `INGESTION_INTERVAL_MS` env vars

### Tests

- **`ExternalNewsClientTest`** — 4 unit tests using `MockWebServer`: success response with 2 articles, empty articles list, 401 error, 500 error
- **`IngestionServiceTest`** — 4 unit tests using Mockito: articles returned, empty list, multiple invocations, error propagation

## Build Summary

- Maven build: **SUCCESS**
- Tests: **9 passed / 0 failed**
  - `ExternalNewsClientTest`: 4 passed
  - `IngestionServiceTest`: 4 passed
  - `RealNewsletterApplicationTests`: 1 passed
- Coverage (line): JaCoCo reports non-fatal ASM warnings on Java 25 (pre-existing); tests run and pass successfully

Closes #3

