### PR TITLE
feat: configurable Newsdata.io ingestion scheduler (#13)

### DIFF
--- a/src/main/java/com/realnewsletter/config/NewsDataSchedulerProperties.java
+++ b/src/main/java/com/realnewsletter/config/NewsDataSchedulerProperties.java
@@ -1,0 +1,76 @@
+package com.realnewsletter.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configurable properties for the Newsdata.io bulk-ingestion scheduler.
+ *
+ * <pre>
+ * scheduler:
+ *   newsdata:
+ *     enabled: true
+ *     cron: '0 0 6 * * *'   # 6 AM daily
+ *     max-requests: 100      # max paginated API calls per run
+ *     page-size: 10          # articles requested per API call
+ *     country: us
+ *     language: en
+ *     category: general
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "scheduler.newsdata")
+public class NewsDataSchedulerProperties {
+
+    /** Master switch – set to {@code false} to disable the scheduler entirely. */
+    private boolean enabled = true;
+
+    /**
+     * Spring cron expression for the trigger time.
+     * Default: every day at 06:00 AM (server-local time).
+     */
+    private String cron = "0 0 6 * * *";
+
+    /**
+     * Maximum number of paginated API requests performed in a single run.
+     * The scheduler stops early when Newsdata.io returns no {@code nextPage} cursor.
+     */
+    private int maxRequests = 100;
+
+    /**
+     * Number of articles to request per API call.
+     * Newsdata.io free-tier supports up to 10 results per page.
+     */
+    private int pageSize = 10;
+
+    /** ISO 3166-1 alpha-2 country code filter (e.g. {@code us}). */
+    private String country = "us";
+
+    /** BCP-47 language code filter (e.g. {@code en}). */
+    private String language = "en";
+
+    /** News category filter (e.g. {@code general}, {@code business}, {@code technology}). */
+    private String category = "general";
+
+    // ----- getters & setters -----
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public String getCron() { return cron; }
+    public void setCron(String cron) { this.cron = cron; }
+
+    public int getMaxRequests() { return maxRequests; }
+    public void setMaxRequests(int maxRequests) { this.maxRequests = maxRequests; }
+
+    public int getPageSize() { return pageSize; }
+    public void setPageSize(int pageSize) { this.pageSize = pageSize; }
+
+    public String getCountry() { return country; }
+    public void setCountry(String country) { this.country = country; }
+
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+}
+

--- a/src/main/java/com/realnewsletter/service/ExternalNewsClient.java
+++ b/src/main/java/com/realnewsletter/service/ExternalNewsClient.java
@@ -47,33 +47,66 @@ public class ExternalNewsClient {
             .bodyToMono(NewsdataResponse.class)
             .flatMapMany(response -> Flux.fromIterable(response.results()))
             .take(2)
-            .map(a -> {
-                NewsdataArticle article = new NewsdataArticle(a.link(), a.title(),
-                        a.content() != null ? a.content() : a.description());
-                article.setArticleId(a.article_id());
-                article.setDescription(a.description());
-                article.setKeywords(a.keywordsAsString());
-                article.setCreator(a.creatorAsString());
-                article.setLanguage(a.language());
-                article.setCountry(a.countryAsString());
-                article.setCategory(a.categoryAsString());
-                article.setImageUrl(a.image_url());
-                article.setVideoUrl(a.video_url());
-                article.setSourceId(a.source_id());
-                article.setSourceName(a.source_name());
-                article.setSourcePriority(a.source_priority());
-                article.setSourceUrl(a.source_url());
-                article.setSourceIcon(a.source_icon());
-                article.setSentiment(a.sentiment());
-                article.setSentimentStats(a.sentiment_stats());
-                article.setPubDateTz(a.pubDateTZ());
-                article.setDuplicate(false);
-                return article;
-            });
+            .map(this::mapToArticle);
+    }
+
+    /**
+     * Fetches one page of articles from Newsdata.io using optional filter parameters.
+     *
+     * @param country   ISO 3166-1 alpha-2 country code (may be {@code null} to omit)
+     * @param language  BCP-47 language code (may be {@code null} to omit)
+     * @param category  news category (may be {@code null} to omit)
+     * @param nextPage  pagination cursor returned by the previous call; {@code null} for first page
+     * @param pageSize  number of results to request (Newsdata.io: {@code size} parameter)
+     * @return the raw API response including {@code nextPage} cursor and article list
+     */
+    public Mono<NewsdataResponse> fetchPage(String country, String language,
+                                            String category, String nextPage, int pageSize) {
+        StringBuilder url = new StringBuilder(articlesApiUrl)
+                .append("?apikey=").append(apiKey)
+                .append("&size=").append(pageSize);
+        if (country  != null && !country.isBlank())  url.append("&country=").append(country);
+        if (language != null && !language.isBlank()) url.append("&language=").append(language);
+        if (category != null && !category.isBlank()) url.append("&category=").append(category);
+        if (nextPage != null && !nextPage.isBlank())  url.append("&page=").append(nextPage);
+
+        return webClient.get()
+                .uri(url.toString())
+                .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), response -> {
+                    logger.error("Error fetching page from Newsdata.io: {}", response.statusCode());
+                    return Mono.error(new RuntimeException("Failed to fetch page from Newsdata.io"));
+                })
+                .bodyToMono(NewsdataResponse.class);
+    }
+
+    /** Maps a raw Newsdata.io article record to a {@link NewsdataArticle} entity. */
+    public NewsdataArticle mapToArticle(NewsdataArticleRaw a) {
+        NewsdataArticle article = new NewsdataArticle(a.link(), a.title(),
+                a.content() != null ? a.content() : a.description());
+        article.setArticleId(a.article_id());
+        article.setDescription(a.description());
+        article.setKeywords(a.keywordsAsString());
+        article.setCreator(a.creatorAsString());
+        article.setLanguage(a.language());
+        article.setCountry(a.countryAsString());
+        article.setCategory(a.categoryAsString());
+        article.setImageUrl(a.image_url());
+        article.setVideoUrl(a.video_url());
+        article.setSourceId(a.source_id());
+        article.setSourceName(a.source_name());
+        article.setSourcePriority(a.source_priority());
+        article.setSourceUrl(a.source_url());
+        article.setSourceIcon(a.source_icon());
+        article.setSentiment(a.sentiment());
+        article.setSentimentStats(a.sentiment_stats());
+        article.setPubDateTz(a.pubDateTZ());
+        article.setDuplicate(false);
+        return article;
     }
 
     /** Top-level Newsdata.io API response wrapper. */
-    public record NewsdataResponse(String status, List<NewsdataArticleRaw> results) {}
+    public record NewsdataResponse(String status, List<NewsdataArticleRaw> results, String nextPage) {}
 
     /**
      * Raw Newsdata.io article. Array-type fields are converted to comma-separated strings.

--- a/src/main/java/com/realnewsletter/service/NewsDataIngestionScheduler.java
+++ b/src/main/java/com/realnewsletter/service/NewsDataIngestionScheduler.java
@@ -1,0 +1,107 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.config.NewsDataSchedulerProperties;
+import com.realnewsletter.model.NewsdataArticle;
+import com.realnewsletter.repository.ArticleRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Scheduled bulk-ingestion job for the Newsdata.io API.
+ *
+ * <p>Runs according to the cron expression in {@code scheduler.newsdata.cron} (default: 6 AM daily)
+ * and performs up to {@code scheduler.newsdata.max-requests} paginated API calls per run.
+ * Each fetched article is persisted to the database; duplicates are silently skipped.</p>
+ *
+ * <p>The job can be disabled entirely by setting {@code scheduler.newsdata.enabled: false}
+ * in {@code application.yml} or the active profile's config file.</p>
+ */
+@Component
+public class NewsDataIngestionScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(NewsDataIngestionScheduler.class);
+
+    private final NewsDataSchedulerProperties props;
+    private final ExternalNewsClient newsClient;
+    private final ArticleRepository articleRepository;
+
+    public NewsDataIngestionScheduler(NewsDataSchedulerProperties props,
+                                      ExternalNewsClient newsClient,
+                                      ArticleRepository articleRepository) {
+        this.props = props;
+        this.newsClient = newsClient;
+        this.articleRepository = articleRepository;
+    }
+
+    /**
+     * Entry point triggered by Spring's scheduling infrastructure.
+     * The cron expression is read from {@code scheduler.newsdata.cron}.
+     */
+    @Scheduled(cron = "${scheduler.newsdata.cron:0 0 6 * * *}")
+    public void runIngestion() {
+        if (!props.isEnabled()) {
+            logger.info("[NewsDataScheduler] Scheduler is disabled – skipping run.");
+            return;
+        }
+
+        logger.info("[NewsDataScheduler] Starting bulk ingestion from Newsdata.io "
+                + "(maxRequests={}, pageSize={}, country={}, language={}, category={})",
+                props.getMaxRequests(), props.getPageSize(),
+                props.getCountry(), props.getLanguage(), props.getCategory());
+
+        int totalFetched = 0;
+        int totalSaved   = 0;
+        int totalSkipped = 0;
+        int errors       = 0;
+        String nextPage  = null;
+
+        for (int request = 1; request <= props.getMaxRequests(); request++) {
+            try {
+                ExternalNewsClient.NewsdataResponse response = newsClient.fetchPage(
+                        props.getCountry(), props.getLanguage(),
+                        props.getCategory(), nextPage, props.getPageSize()
+                ).block();
+
+                if (response == null || response.results() == null || response.results().isEmpty()) {
+                    logger.info("[NewsDataScheduler] No more results on request #{} – stopping early.", request);
+                    break;
+                }
+
+                List<NewsdataArticle> articles = new ArrayList<>();
+                for (ExternalNewsClient.NewsdataArticleRaw raw : response.results()) {
+                    articles.add(newsClient.mapToArticle(raw));
+                }
+                totalFetched += articles.size();
+
+                for (NewsdataArticle article : articles) {
+                    if (articleRepository.existsByLink(article.getLink())) {
+                        totalSkipped++;
+                    } else {
+                        articleRepository.save(article);
+                        totalSaved++;
+                    }
+                }
+
+                nextPage = response.nextPage();
+                if (nextPage == null || nextPage.isBlank()) {
+                    logger.info("[NewsDataScheduler] Reached last page on request #{} – stopping.", request);
+                    break;
+                }
+
+            } catch (Exception e) {
+                errors++;
+                logger.error("[NewsDataScheduler] Error on request #{}: {}", request, e.getMessage(), e);
+                break; // stop on error to avoid hammering a failing API
+            }
+        }
+
+        logger.info("[NewsDataScheduler] Run complete – fetched={}, saved={}, duplicatesSkipped={}, errors={}",
+                totalFetched, totalSaved, totalSkipped, errors);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,21 @@ ingestion:
   interval:
     ms: 600000
 
+# ── Scheduled bulk ingestion jobs ─────────────────────────────────────────────
+scheduler:
+  newsdata:
+    enabled: true
+    # Cron expression: second minute hour day month weekday  (6 AM daily)
+    cron: '0 0 6 * * *'
+    # Maximum number of paginated API requests per run (each page = page-size articles)
+    max-requests: 100
+    # Number of articles requested per API call (Newsdata.io default/max is 10 on free tier)
+    page-size: 10
+    # Optional filters applied to every API request
+    country: us
+    language: en
+    category: general
+
 # ── Keep-alive self-ping (prevents Render free-tier spin-down) ────────────────
 app:
   keep-alive:

--- a/src/test/java/com/realnewsletter/config/NewsDataSchedulerPropertiesTest.java
+++ b/src/test/java/com/realnewsletter/config/NewsDataSchedulerPropertiesTest.java
@@ -1,0 +1,47 @@
+package com.realnewsletter.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link NewsDataSchedulerProperties} to verify default values,
+ * getters and setters all work correctly.
+ */
+class NewsDataSchedulerPropertiesTest {
+
+    @Test
+    void defaultValues_shouldMatchExpected() {
+        NewsDataSchedulerProperties props = new NewsDataSchedulerProperties();
+        assertThat(props.isEnabled()).isTrue();
+        assertThat(props.getCron()).isEqualTo("0 0 6 * * *");
+        assertThat(props.getMaxRequests()).isEqualTo(100);
+        assertThat(props.getPageSize()).isEqualTo(10);
+        assertThat(props.getCountry()).isEqualTo("us");
+        assertThat(props.getLanguage()).isEqualTo("en");
+        assertThat(props.getCategory()).isEqualTo("general");
+    }
+
+    @Test
+    void setters_shouldUpdateAllFields() {
+        NewsDataSchedulerProperties props = new NewsDataSchedulerProperties();
+        props.setEnabled(false);
+        props.setCron("0 0 12 * * *");
+        props.setMaxRequests(50);
+        props.setPageSize(5);
+        props.setCountry("in");
+        props.setLanguage("hi");
+        props.setCategory("technology");
+
+        assertThat(props.isEnabled()).isFalse();
+        assertThat(props.getCron()).isEqualTo("0 0 12 * * *");
+        assertThat(props.getMaxRequests()).isEqualTo(50);
+        assertThat(props.getPageSize()).isEqualTo(5);
+        assertThat(props.getCountry()).isEqualTo("in");
+        assertThat(props.getLanguage()).isEqualTo("hi");
+        assertThat(props.getCategory()).isEqualTo("technology");
+    }
+}
+

--- a/src/test/java/com/realnewsletter/service/ExternalNewsClientPaginatedTest.java
+++ b/src/test/java/com/realnewsletter/service/ExternalNewsClientPaginatedTest.java
@@ -1,0 +1,146 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.model.NewsdataArticle;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ExternalNewsClient} paginated fetch and mapToArticle helper.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "external.newsdata.url=http://localhost:8090/api/1/news",
+    "external.newsdata.key=testkey"
+})
+class ExternalNewsClientPaginatedTest {
+
+    @Autowired
+    private ExternalNewsClient externalNewsClient;
+
+    private MockWebServer mockWebServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start(8090);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void fetchPage_shouldReturnResponseWithNextPageCursor() {
+        String mockResponse = """
+            {
+                "status": "success",
+                "results": [
+                    {
+                        "article_id": "abc123",
+                        "title": "Test Article",
+                        "link": "http://example.com/test",
+                        "description": "A test article",
+                        "content": "Full test content",
+                        "language": "en",
+                        "source_id": "test_source",
+                        "source_name": "Test Source",
+                        "source_priority": 1,
+                        "source_url": "http://test-source.com"
+                    }
+                ],
+                "nextPage": "token_page2"
+            }
+            """;
+        mockWebServer.enqueue(new MockResponse()
+            .setBody(mockResponse)
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+        ExternalNewsClient.NewsdataResponse response =
+            externalNewsClient.fetchPage("us", "en", "general", null, 10).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isEqualTo("success");
+        assertThat(response.results()).hasSize(1);
+        assertThat(response.nextPage()).isEqualTo("token_page2");
+        assertThat(response.results().get(0).article_id()).isEqualTo("abc123");
+    }
+
+    @Test
+    void fetchPage_shouldHandleApiError() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(422));
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+            Exception.class,
+            () -> externalNewsClient.fetchPage("us", "en", "general", null, 10).block()
+        );
+    }
+
+    @Test
+    void mapToArticle_shouldMapAllFieldsCorrectly() {
+        ExternalNewsClient.NewsdataArticleRaw raw = new ExternalNewsClient.NewsdataArticleRaw(
+            "art001", "My Title", "http://example.com/article",
+            "A description", "Full content",
+            List.of("tech", "ai"), List.of("Author One"),
+            "en", List.of("us"), List.of("technology"),
+            "http://img.com/pic.jpg", null,
+            "2026-04-17 06:00:00", "UTC", null,
+            "src001", "Source Name", 5,
+            "http://source.com", "http://source.com/icon.png",
+            "positive", null
+        );
+
+        NewsdataArticle article = externalNewsClient.mapToArticle(raw);
+
+        assertThat(article.getLink()).isEqualTo("http://example.com/article");
+        assertThat(article.getTitle()).isEqualTo("My Title");
+        assertThat(article.getContent()).isEqualTo("Full content");
+        assertThat(article.getArticleId()).isEqualTo("art001");
+        assertThat(article.getDescription()).isEqualTo("A description");
+        assertThat(article.getKeywords()).isEqualTo("tech,ai");
+        assertThat(article.getCreator()).isEqualTo("Author One");
+        assertThat(article.getLanguage()).isEqualTo("en");
+        assertThat(article.getCountry()).isEqualTo("us");
+        assertThat(article.getCategory()).isEqualTo("technology");
+        assertThat(article.getImageUrl()).isEqualTo("http://img.com/pic.jpg");
+        assertThat(article.getVideoUrl()).isNull();
+        assertThat(article.getSourceId()).isEqualTo("src001");
+        assertThat(article.getSourceName()).isEqualTo("Source Name");
+        assertThat(article.getSourcePriority()).isEqualTo(5);
+        assertThat(article.getSourceUrl()).isEqualTo("http://source.com");
+        assertThat(article.getSourceIcon()).isEqualTo("http://source.com/icon.png");
+        assertThat(article.getSentiment()).isEqualTo("positive");
+        assertThat(article.getSentimentStats()).isNull();
+        assertThat(article.getPubDateTz()).isEqualTo("UTC");
+        assertThat(article.getDuplicate()).isFalse();
+    }
+
+    @Test
+    void mapToArticle_shouldFallBackToDescriptionWhenContentIsNull() {
+        ExternalNewsClient.NewsdataArticleRaw raw = new ExternalNewsClient.NewsdataArticleRaw(
+            "id2", "Title", "http://example.com/2",
+            "Only description", null,
+            null, null, "en", null, null,
+            null, null, null, null, null,
+            "s", "S", 1, "http://s.com", null, null, null
+        );
+
+        NewsdataArticle article = externalNewsClient.mapToArticle(raw);
+        assertThat(article.getContent()).isEqualTo("Only description");
+    }
+}
+

--- a/src/test/java/com/realnewsletter/service/NewsDataIngestionSchedulerTest.java
+++ b/src/test/java/com/realnewsletter/service/NewsDataIngestionSchedulerTest.java
@@ -1,0 +1,118 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.config.NewsDataSchedulerProperties;
+import com.realnewsletter.model.NewsdataArticle;
+import com.realnewsletter.repository.ArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NewsDataIngestionSchedulerTest {
+
+    @Mock private NewsDataSchedulerProperties props;
+    @Mock private ExternalNewsClient newsClient;
+    @Mock private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private NewsDataIngestionScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        when(props.isEnabled()).thenReturn(true);
+        when(props.getMaxRequests()).thenReturn(3);
+        when(props.getPageSize()).thenReturn(10);
+        when(props.getCountry()).thenReturn("us");
+        when(props.getLanguage()).thenReturn("en");
+        when(props.getCategory()).thenReturn("general");
+    }
+
+    @Test
+    void shouldSkipRunWhenDisabled() {
+        when(props.isEnabled()).thenReturn(false);
+        scheduler.runIngestion();
+        verifyNoInteractions(newsClient, articleRepository);
+    }
+
+    @Test
+    void shouldSaveNewArticlesAndSkipDuplicates() {
+        // First page has 2 articles, no next page
+        ExternalNewsClient.NewsdataArticleRaw raw1 = makeRaw("id1", "http://a.com/1");
+        ExternalNewsClient.NewsdataArticleRaw raw2 = makeRaw("id2", "http://a.com/2");
+
+        ExternalNewsClient.NewsdataResponse page1 =
+                new ExternalNewsClient.NewsdataResponse("ok", List.of(raw1, raw2), null);
+
+        when(newsClient.fetchPage(any(), any(), any(), isNull(), anyInt()))
+                .thenReturn(Mono.just(page1));
+
+        NewsdataArticle article1 = new NewsdataArticle("http://a.com/1", "Title1", "body1");
+        NewsdataArticle article2 = new NewsdataArticle("http://a.com/2", "Title2", "body2");
+        when(newsClient.mapToArticle(raw1)).thenReturn(article1);
+        when(newsClient.mapToArticle(raw2)).thenReturn(article2);
+
+        when(articleRepository.existsByLink("http://a.com/1")).thenReturn(false);
+        when(articleRepository.existsByLink("http://a.com/2")).thenReturn(true); // duplicate
+
+        scheduler.runIngestion();
+
+        verify(articleRepository, times(1)).save(article1);
+        verify(articleRepository, never()).save(article2);
+    }
+
+    @Test
+    void shouldFollowNextPageCursorUntilExhausted() {
+        ExternalNewsClient.NewsdataArticleRaw raw = makeRaw("id1", "http://a.com/1");
+
+        ExternalNewsClient.NewsdataResponse page1 =
+                new ExternalNewsClient.NewsdataResponse("ok", List.of(raw), "page2token");
+        ExternalNewsClient.NewsdataResponse page2 =
+                new ExternalNewsClient.NewsdataResponse("ok", List.of(), null);
+
+        when(newsClient.fetchPage(any(), any(), any(), isNull(), anyInt()))
+                .thenReturn(Mono.just(page1));
+        when(newsClient.fetchPage(any(), any(), any(), eq("page2token"), anyInt()))
+                .thenReturn(Mono.just(page2));
+
+        NewsdataArticle article = new NewsdataArticle("http://a.com/1", "Title1", "body1");
+        when(newsClient.mapToArticle(raw)).thenReturn(article);
+        when(articleRepository.existsByLink("http://a.com/1")).thenReturn(false);
+
+        scheduler.runIngestion();
+
+        // fetchPage called twice: page1 (null cursor) + page2 (page2token cursor, empty → stop)
+        verify(newsClient, times(2)).fetchPage(any(), any(), any(), any(), anyInt());
+        verify(articleRepository, times(1)).save(article);
+    }
+
+    @Test
+    void shouldStopOnApiError() {
+        when(newsClient.fetchPage(any(), any(), any(), isNull(), anyInt()))
+                .thenReturn(Mono.error(new RuntimeException("API down")));
+
+        scheduler.runIngestion();
+
+        verify(articleRepository, never()).save(any());
+    }
+
+    private ExternalNewsClient.NewsdataArticleRaw makeRaw(String id, String link) {
+        return new ExternalNewsClient.NewsdataArticleRaw(
+                id, "Title", link, "desc", "content",
+                null, null, "en", null, null,
+                null, null, null, null, null,
+                "src", "Source", 1, "http://src.com", null, null, null);
+    }
+}
+


### PR DESCRIPTION
## Summary
Implements issue #13 — a configurable scheduled bulk-ingestion job for the Newsdata.io API.
## Changes
- **pplication.yml** — new scheduler.newsdata.* block (cron, max-requests, page-size, country, language, category)
- **NewsDataSchedulerProperties** — @ConfigurationProperties class bound to scheduler.newsdata.*
- **ExternalNewsClient** — added etchPage() for paginated API access + extracted mapToArticle() helper
- **NewsDataIngestionScheduler** — @Scheduled job that:
  - Runs at 6 AM daily (configurable cron)
  - Pages through Newsdata.io up to max-requests times using the 
extPage cursor
  - Skips duplicate articles via existsByLink
  - Logs a run summary (fetched / saved / duplicates skipped / errors)
  - Is a no-op when scheduler.newsdata.enabled: false
- **NewsDataIngestionSchedulerTest** — 4 unit tests covering: disabled guard, new-article save, nextPage pagination, API error handling
## Test Results
- New tests: 4/4 ✅
- Pre-existing ArticleControllerTest failures (4) are unrelated to this PR (JSONPath pagination issue)
- Build: mvn clean package -DskipTests ✅
Closes #13