### PR TITLE
feat: configurable NewsAPI.org ingestion scheduler (#14)

### DIFF
--- a/src/main/java/com/realnewsletter/config/NewsApiSchedulerProperties.java
+++ b/src/main/java/com/realnewsletter/config/NewsApiSchedulerProperties.java
@@ -1,0 +1,76 @@
+package com.realnewsletter.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configurable properties for the NewsAPI.org bulk-ingestion scheduler.
+ *
+ * <pre>
+ * scheduler:
+ *   newsapi:
+ *     enabled: true
+ *     cron: '0 0 7 * * *'   # 7 AM daily
+ *     max-requests: 50       # max paginated API calls per run
+ *     page-size: 20          # articles requested per API call
+ *     country: us
+ *     language: en
+ *     category: general
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "scheduler.newsapi")
+public class NewsApiSchedulerProperties {
+
+    /** Master switch – set to {@code false} to disable the scheduler entirely. */
+    private boolean enabled = true;
+
+    /**
+     * Spring cron expression for the trigger time.
+     * Default: every day at 07:00 AM (server-local time).
+     */
+    private String cron = "0 0 7 * * *";
+
+    /**
+     * Maximum number of paginated API requests performed in a single run.
+     * The scheduler stops early when no more articles are returned.
+     */
+    private int maxRequests = 50;
+
+    /**
+     * Number of articles to request per API call ({@code pageSize} parameter).
+     * NewsAPI free-tier supports up to 100 results per page.
+     */
+    private int pageSize = 20;
+
+    /** ISO 3166-1 alpha-2 country code filter (e.g. {@code us}). */
+    private String country = "us";
+
+    /** BCP-47 language code filter (e.g. {@code en}). */
+    private String language = "en";
+
+    /** News category filter (e.g. {@code general}, {@code business}, {@code technology}). */
+    private String category = "general";
+
+    // ----- getters & setters -----
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public String getCron() { return cron; }
+    public void setCron(String cron) { this.cron = cron; }
+
+    public int getMaxRequests() { return maxRequests; }
+    public void setMaxRequests(int maxRequests) { this.maxRequests = maxRequests; }
+
+    public int getPageSize() { return pageSize; }
+    public void setPageSize(int pageSize) { this.pageSize = pageSize; }
+
+    public String getCountry() { return country; }
+    public void setCountry(String country) { this.country = country; }
+
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+}
+

--- a/src/main/java/com/realnewsletter/service/NewsApiClient.java
+++ b/src/main/java/com/realnewsletter/service/NewsApiClient.java
@@ -34,7 +34,7 @@ public class NewsApiClient {
     }
 
     /**
-     * Fetches top US headlines from NewsAPI.org.
+     * Fetches top headlines from NewsAPI.org.
      *
      * @return Flux of {@link NewsApiArticle}
      */
@@ -53,22 +53,59 @@ public class NewsApiClient {
                 .bodyToMono(NewsApiResponse.class)
                 .flatMapMany(response -> Flux.fromIterable(response.articles()))
                 .take(2)
-                .map(a -> {
-                    NewsApiArticle article = new NewsApiArticle(a.url(), a.title(), a.content());
-                    article.setDescription(a.description());
-                    article.setCreator(a.author());
-                    article.setImageUrl(a.urlToImage());
-                    article.setSourceId(a.source() != null ? a.source().id() : null);
-                    article.setSourceName(a.source() != null ? a.source().name() : null);
-                    if (a.publishedAt() != null) {
-                        try {
-                            article.setPubDate(Instant.parse(a.publishedAt()));
-                        } catch (Exception e) {
-                            logger.warn("Could not parse publishedAt: {}", a.publishedAt());
-                        }
-                    }
-                    return article;
-                });
+                .map(this::mapToArticle);
+    }
+
+    /**
+     * Fetches one page of top headlines from NewsAPI.org with optional filters.
+     *
+     * @param country   ISO 3166-1 alpha-2 country code (may be {@code null} to omit)
+     * @param language  BCP-47 language code (may be {@code null} to omit)
+     * @param category  news category (may be {@code null} to omit)
+     * @param page      1-based page number (1 = first page)
+     * @param pageSize  number of results to request
+     * @return the raw API response including totalResults and articles list
+     */
+    public Mono<NewsApiResponse> fetchPage(String country, String language,
+                                           String category, int page, int pageSize) {
+        if (newsApiKey == null || newsApiKey.isBlank()) {
+            logger.warn("NewsAPI key not configured – returning empty response");
+            return Mono.just(new NewsApiResponse("ok", 0, List.of()));
+        }
+        StringBuilder url = new StringBuilder(newsApiUrl)
+                .append("?apiKey=").append(newsApiKey)
+                .append("&page=").append(page)
+                .append("&pageSize=").append(pageSize);
+        if (country  != null && !country.isBlank())  url.append("&country=").append(country);
+        if (language != null && !language.isBlank()) url.append("&language=").append(language);
+        if (category != null && !category.isBlank()) url.append("&category=").append(category);
+
+        return webClient.get()
+                .uri(url.toString())
+                .retrieve()
+                .onStatus(status -> !status.is2xxSuccessful(), response -> {
+                    logger.error("Error fetching page {} from NewsAPI: {}", page, response.statusCode());
+                    return Mono.error(new RuntimeException("Failed to fetch page from NewsAPI"));
+                })
+                .bodyToMono(NewsApiResponse.class);
+    }
+
+    /** Maps a raw NewsAPI article record to a {@link NewsApiArticle} entity. */
+    public NewsApiArticle mapToArticle(NewsApiArticleRaw a) {
+        NewsApiArticle article = new NewsApiArticle(a.url(), a.title(), a.content());
+        article.setDescription(a.description());
+        article.setCreator(a.author());
+        article.setImageUrl(a.urlToImage());
+        article.setSourceId(a.source() != null ? a.source().id() : null);
+        article.setSourceName(a.source() != null ? a.source().name() : null);
+        if (a.publishedAt() != null) {
+            try {
+                article.setPubDate(Instant.parse(a.publishedAt()));
+            } catch (Exception e) {
+                logger.warn("Could not parse publishedAt: {}", a.publishedAt());
+            }
+        }
+        return article;
     }
 
     /** Top-level NewsAPI response wrapper. */

--- a/src/main/java/com/realnewsletter/service/NewsApiIngestionScheduler.java
+++ b/src/main/java/com/realnewsletter/service/NewsApiIngestionScheduler.java
@@ -1,0 +1,117 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.config.NewsApiSchedulerProperties;
+import com.realnewsletter.model.NewsApiArticle;
+import com.realnewsletter.repository.ArticleRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Scheduled bulk-ingestion job for the NewsAPI.org API.
+ *
+ * <p>Runs according to the cron expression in {@code scheduler.newsapi.cron} (default: 7 AM daily)
+ * and performs up to {@code scheduler.newsapi.max-requests} paginated API calls per run.
+ * Each fetched article is persisted to the database; duplicates are silently skipped.</p>
+ *
+ * <p>The job can be disabled entirely by setting {@code scheduler.newsapi.enabled: false}
+ * in {@code application.yml} or the active profile's config file.</p>
+ */
+@Component
+public class NewsApiIngestionScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(NewsApiIngestionScheduler.class);
+
+    private final NewsApiSchedulerProperties props;
+    private final NewsApiClient newsApiClient;
+    private final ArticleRepository articleRepository;
+
+    public NewsApiIngestionScheduler(NewsApiSchedulerProperties props,
+                                     NewsApiClient newsApiClient,
+                                     ArticleRepository articleRepository) {
+        this.props = props;
+        this.newsApiClient = newsApiClient;
+        this.articleRepository = articleRepository;
+    }
+
+    /**
+     * Entry point triggered by Spring's scheduling infrastructure.
+     * The cron expression is read from {@code scheduler.newsapi.cron}.
+     */
+    @Scheduled(cron = "${scheduler.newsapi.cron:0 0 7 * * *}")
+    public void runIngestion() {
+        if (!props.isEnabled()) {
+            logger.info("[NewsApiScheduler] Scheduler is disabled – skipping run.");
+            return;
+        }
+
+        logger.info("[NewsApiScheduler] Starting bulk ingestion from NewsAPI.org "
+                + "(maxRequests={}, pageSize={}, country={}, language={}, category={})",
+                props.getMaxRequests(), props.getPageSize(),
+                props.getCountry(), props.getLanguage(), props.getCategory());
+
+        int totalFetched = 0;
+        int totalSaved   = 0;
+        int totalSkipped = 0;
+        int errors       = 0;
+
+        for (int page = 1; page <= props.getMaxRequests(); page++) {
+            try {
+                NewsApiClient.NewsApiResponse response = newsApiClient.fetchPage(
+                        props.getCountry(), props.getLanguage(),
+                        props.getCategory(), page, props.getPageSize()
+                ).block();
+
+                if (response == null || response.articles() == null || response.articles().isEmpty()) {
+                    logger.info("[NewsApiScheduler] No more results on page {} – stopping early.", page);
+                    break;
+                }
+
+                List<NewsApiArticle> articles = response.articles().stream()
+                        .map(newsApiClient::mapToArticle)
+                        .toList();
+
+                totalFetched += articles.size();
+
+                for (NewsApiArticle article : articles) {
+                    if (article.getLink() == null || article.getLink().isBlank()) {
+                        totalSkipped++;
+                        continue;
+                    }
+                    if (articleRepository.existsByLink(article.getLink())) {
+                        totalSkipped++;
+                    } else {
+                        articleRepository.save(article);
+                        totalSaved++;
+                    }
+                }
+
+                // Stop when the page returned fewer articles than requested — last page reached
+                if (articles.size() < props.getPageSize()) {
+                    logger.info("[NewsApiScheduler] Partial page ({} articles) on page {} – stopping.",
+                            articles.size(), page);
+                    break;
+                }
+
+                // Stop when total results exhausted
+                int totalResults = response.totalResults() != null ? response.totalResults() : 0;
+                if (totalFetched >= totalResults) {
+                    logger.info("[NewsApiScheduler] All {} total results fetched – stopping.", totalResults);
+                    break;
+                }
+
+            } catch (Exception e) {
+                errors++;
+                logger.error("[NewsApiScheduler] Error on page {}: {}", page, e.getMessage(), e);
+                break; // stop on error to avoid hammering a failing API
+            }
+        }
+
+        logger.info("[NewsApiScheduler] Run complete – fetched={}, saved={}, duplicatesSkipped={}, errors={}",
+                totalFetched, totalSaved, totalSkipped, errors);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,18 @@ scheduler:
     country: us
     language: en
     category: general
+  newsapi:
+    enabled: true
+    # Cron expression: second minute hour day month weekday  (7 AM daily)
+    cron: '0 0 7 * * *'
+    # Maximum number of paginated API requests per run
+    max-requests: 50
+    # Number of articles per API call (NewsAPI free tier max = 100; set lower to stay within limits)
+    page-size: 20
+    # Optional filters applied to every API request
+    country: us
+    language: en
+    category: general
 
 # ── Keep-alive self-ping (prevents Render free-tier spin-down) ────────────────
 app:

--- a/src/test/java/com/realnewsletter/config/NewsApiSchedulerPropertiesTest.java
+++ b/src/test/java/com/realnewsletter/config/NewsApiSchedulerPropertiesTest.java
@@ -1,0 +1,41 @@
+package com.realnewsletter.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NewsApiSchedulerPropertiesTest {
+
+    @Test
+    void defaultValues_shouldMatchExpected() {
+        NewsApiSchedulerProperties props = new NewsApiSchedulerProperties();
+        assertThat(props.isEnabled()).isTrue();
+        assertThat(props.getCron()).isEqualTo("0 0 7 * * *");
+        assertThat(props.getMaxRequests()).isEqualTo(50);
+        assertThat(props.getPageSize()).isEqualTo(20);
+        assertThat(props.getCountry()).isEqualTo("us");
+        assertThat(props.getLanguage()).isEqualTo("en");
+        assertThat(props.getCategory()).isEqualTo("general");
+    }
+
+    @Test
+    void setters_shouldUpdateAllFields() {
+        NewsApiSchedulerProperties props = new NewsApiSchedulerProperties();
+        props.setEnabled(false);
+        props.setCron("0 0 8 * * *");
+        props.setMaxRequests(10);
+        props.setPageSize(5);
+        props.setCountry("in");
+        props.setLanguage("hi");
+        props.setCategory("technology");
+
+        assertThat(props.isEnabled()).isFalse();
+        assertThat(props.getCron()).isEqualTo("0 0 8 * * *");
+        assertThat(props.getMaxRequests()).isEqualTo(10);
+        assertThat(props.getPageSize()).isEqualTo(5);
+        assertThat(props.getCountry()).isEqualTo("in");
+        assertThat(props.getLanguage()).isEqualTo("hi");
+        assertThat(props.getCategory()).isEqualTo("technology");
+    }
+}
+

--- a/src/test/java/com/realnewsletter/service/NewsApiClientPaginatedTest.java
+++ b/src/test/java/com/realnewsletter/service/NewsApiClientPaginatedTest.java
@@ -1,0 +1,143 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.model.NewsApiArticle;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Integration tests for {@link NewsApiClient} paginated fetch and mapToArticle helper.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "external.newsapi.url=http://localhost:8091/v2/top-headlines",
+    "external.newsapi.key=testkey"
+})
+class NewsApiClientPaginatedTest {
+
+    @Autowired
+    private NewsApiClient newsApiClient;
+
+    private MockWebServer mockWebServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start(8091);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void fetchPage_shouldReturnArticlesAndTotalResults() {
+        String mockResponse = """
+            {
+                "status": "ok",
+                "totalResults": 2,
+                "articles": [
+                    {
+                        "source": { "id": "bbc-news", "name": "BBC News" },
+                        "author": "Reporter One",
+                        "title": "Breaking News",
+                        "description": "Something happened",
+                        "url": "https://bbc.com/news/1",
+                        "urlToImage": "https://img.bbc.com/1.jpg",
+                        "publishedAt": "2026-04-17T07:00:00Z",
+                        "content": "Full article content here"
+                    }
+                ]
+            }
+            """;
+        mockWebServer.enqueue(new MockResponse()
+            .setBody(mockResponse)
+            .setResponseCode(200)
+            .addHeader("Content-Type", "application/json"));
+
+        NewsApiClient.NewsApiResponse response =
+            newsApiClient.fetchPage("us", "en", "general", 1, 20).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isEqualTo("ok");
+        assertThat(response.totalResults()).isEqualTo(2);
+        assertThat(response.articles()).hasSize(1);
+        assertThat(response.articles().get(0).title()).isEqualTo("Breaking News");
+        assertThat(response.articles().get(0).source().name()).isEqualTo("BBC News");
+    }
+
+    @Test
+    void fetchPage_shouldHandleApiError() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        assertThrows(Exception.class,
+            () -> newsApiClient.fetchPage("us", "en", "general", 1, 20).block());
+    }
+
+    @Test
+    void mapToArticle_shouldMapAllFieldsCorrectly() {
+        NewsApiClient.NewsApiArticleRaw raw = new NewsApiClient.NewsApiArticleRaw(
+            new NewsApiClient.NewsApiSource("cnn", "CNN"),
+            "Jane Doe",
+            "Big Story",
+            "A big story happened",
+            "https://cnn.com/story/1",
+            "https://img.cnn.com/story.jpg",
+            "2026-04-17T09:00:00Z",
+            "Full story content"
+        );
+
+        NewsApiArticle article = newsApiClient.mapToArticle(raw);
+
+        assertThat(article.getLink()).isEqualTo("https://cnn.com/story/1");
+        assertThat(article.getTitle()).isEqualTo("Big Story");
+        assertThat(article.getContent()).isEqualTo("Full story content");
+        assertThat(article.getDescription()).isEqualTo("A big story happened");
+        assertThat(article.getCreator()).isEqualTo("Jane Doe");
+        assertThat(article.getImageUrl()).isEqualTo("https://img.cnn.com/story.jpg");
+        assertThat(article.getSourceId()).isEqualTo("cnn");
+        assertThat(article.getSourceName()).isEqualTo("CNN");
+        assertThat(article.getPubDate()).isNotNull();
+    }
+
+    @Test
+    void mapToArticle_shouldHandleNullSource() {
+        NewsApiClient.NewsApiArticleRaw raw = new NewsApiClient.NewsApiArticleRaw(
+            null, "Author", "Title", "Desc",
+            "https://example.com/1", null,
+            "2026-04-17T09:00:00Z", "Content"
+        );
+
+        NewsApiArticle article = newsApiClient.mapToArticle(raw);
+
+        assertThat(article.getSourceId()).isNull();
+        assertThat(article.getSourceName()).isNull();
+    }
+
+    @Test
+    void mapToArticle_shouldHandleInvalidPublishedAt() {
+        NewsApiClient.NewsApiArticleRaw raw = new NewsApiClient.NewsApiArticleRaw(
+            null, "Author", "Title", "Desc",
+            "https://example.com/1", null,
+            "not-a-date", "Content"
+        );
+
+        // Should not throw; pubDate will simply be null
+        NewsApiArticle article = newsApiClient.mapToArticle(raw);
+        assertThat(article.getPubDate()).isNull();
+    }
+}
+

--- a/src/test/java/com/realnewsletter/service/NewsApiIngestionSchedulerTest.java
+++ b/src/test/java/com/realnewsletter/service/NewsApiIngestionSchedulerTest.java
@@ -1,0 +1,160 @@
+package com.realnewsletter.service;
+
+import com.realnewsletter.config.NewsApiSchedulerProperties;
+import com.realnewsletter.model.NewsApiArticle;
+import com.realnewsletter.repository.ArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NewsApiIngestionSchedulerTest {
+
+    @Mock private NewsApiSchedulerProperties props;
+    @Mock private NewsApiClient newsApiClient;
+    @Mock private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private NewsApiIngestionScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        when(props.isEnabled()).thenReturn(true);
+        when(props.getMaxRequests()).thenReturn(3);
+        when(props.getPageSize()).thenReturn(20);
+        when(props.getCountry()).thenReturn("us");
+        when(props.getLanguage()).thenReturn("en");
+        when(props.getCategory()).thenReturn("general");
+    }
+
+    @Test
+    void shouldSkipRunWhenDisabled() {
+        when(props.isEnabled()).thenReturn(false);
+        scheduler.runIngestion();
+        verifyNoInteractions(newsApiClient, articleRepository);
+    }
+
+    @Test
+    void shouldSaveNewArticlesAndSkipDuplicates() {
+        NewsApiClient.NewsApiArticleRaw raw1 = makeRaw("http://a.com/1", "Title 1");
+        NewsApiClient.NewsApiArticleRaw raw2 = makeRaw("http://a.com/2", "Title 2");
+
+        // Page 1 returns 2 articles (< pageSize=20 → last page)
+        NewsApiClient.NewsApiResponse page1 =
+                new NewsApiClient.NewsApiResponse("ok", 2, List.of(raw1, raw2));
+
+        when(newsApiClient.fetchPage(any(), any(), any(), eq(1), anyInt()))
+                .thenReturn(Mono.just(page1));
+
+        NewsApiArticle article1 = new NewsApiArticle("http://a.com/1", "Title 1", "body");
+        NewsApiArticle article2 = new NewsApiArticle("http://a.com/2", "Title 2", "body");
+        when(newsApiClient.mapToArticle(raw1)).thenReturn(article1);
+        when(newsApiClient.mapToArticle(raw2)).thenReturn(article2);
+
+        when(articleRepository.existsByLink("http://a.com/1")).thenReturn(false);
+        when(articleRepository.existsByLink("http://a.com/2")).thenReturn(true); // duplicate
+
+        scheduler.runIngestion();
+
+        verify(articleRepository, times(1)).save(article1);
+        verify(articleRepository, never()).save(article2);
+    }
+
+    @Test
+    void shouldPageThroughMultiplePagesUntilPartialPage() {
+        NewsApiClient.NewsApiArticleRaw raw = makeRaw("http://a.com/1", "T");
+
+        // Page 1: full page (20 articles) — return 20 articles, totalResults=25
+        List<NewsApiClient.NewsApiArticleRaw> fullPage = java.util.Collections.nCopies(20, raw);
+        NewsApiClient.NewsApiResponse page1 =
+                new NewsApiClient.NewsApiResponse("ok", 25, fullPage);
+
+        // Page 2: partial page (5 articles) → stop
+        List<NewsApiClient.NewsApiArticleRaw> partialPage = java.util.Collections.nCopies(5, raw);
+        NewsApiClient.NewsApiResponse page2 =
+                new NewsApiClient.NewsApiResponse("ok", 25, partialPage);
+
+        when(newsApiClient.fetchPage(any(), any(), any(), eq(1), anyInt()))
+                .thenReturn(Mono.just(page1));
+        when(newsApiClient.fetchPage(any(), any(), any(), eq(2), anyInt()))
+                .thenReturn(Mono.just(page2));
+
+        NewsApiArticle article = new NewsApiArticle("http://a.com/1", "T", "b");
+        when(newsApiClient.mapToArticle(raw)).thenReturn(article);
+        when(articleRepository.existsByLink(any())).thenReturn(false);
+
+        scheduler.runIngestion();
+
+        verify(newsApiClient, times(2)).fetchPage(any(), any(), any(), anyInt(), anyInt());
+    }
+
+    @Test
+    void shouldStopWhenTotalResultsExhausted() {
+        NewsApiClient.NewsApiArticleRaw raw = makeRaw("http://a.com/1", "T");
+
+        // Page 1: full page (20), totalResults=20 → all fetched → stop
+        List<NewsApiClient.NewsApiArticleRaw> fullPage = java.util.Collections.nCopies(20, raw);
+        NewsApiClient.NewsApiResponse page1 =
+                new NewsApiClient.NewsApiResponse("ok", 20, fullPage);
+
+        when(newsApiClient.fetchPage(any(), any(), any(), eq(1), anyInt()))
+                .thenReturn(Mono.just(page1));
+
+        NewsApiArticle article = new NewsApiArticle("http://a.com/1", "T", "b");
+        when(newsApiClient.mapToArticle(raw)).thenReturn(article);
+        when(articleRepository.existsByLink(any())).thenReturn(false);
+
+        scheduler.runIngestion();
+
+        // Only 1 page fetched even though maxRequests=3
+        verify(newsApiClient, times(1)).fetchPage(any(), any(), any(), anyInt(), anyInt());
+    }
+
+    @Test
+    void shouldStopOnApiError() {
+        when(newsApiClient.fetchPage(any(), any(), any(), eq(1), anyInt()))
+                .thenReturn(Mono.error(new RuntimeException("API down")));
+
+        scheduler.runIngestion();
+
+        verify(articleRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldSkipArticlesWithNullLink() {
+        NewsApiClient.NewsApiArticleRaw rawNullUrl = makeRaw(null, "Title null url");
+
+        NewsApiClient.NewsApiResponse page1 =
+                new NewsApiClient.NewsApiResponse("ok", 1, List.of(rawNullUrl));
+
+        when(newsApiClient.fetchPage(any(), any(), any(), eq(1), anyInt()))
+                .thenReturn(Mono.just(page1));
+
+        NewsApiArticle article = new NewsApiArticle(null, "Title null url", "body");
+        when(newsApiClient.mapToArticle(rawNullUrl)).thenReturn(article);
+
+        scheduler.runIngestion();
+
+        verify(articleRepository, never()).save(any());
+    }
+
+    private NewsApiClient.NewsApiArticleRaw makeRaw(String url, String title) {
+        return new NewsApiClient.NewsApiArticleRaw(
+                new NewsApiClient.NewsApiSource("src-id", "Source Name"),
+                "Author", title, "description", url,
+                "http://img.com/pic.jpg", "2026-04-17T07:00:00Z", "content body");
+    }
+}
+


### PR DESCRIPTION
## Summary
Implements issue #14 — a configurable scheduled bulk-ingestion job for the NewsAPI.org top-headlines API.
## Changes
- **\pplication.yml\** — new \scheduler.newsapi.*\ block (cron, max-requests, page-size, country, language, category)
- **\NewsApiSchedulerProperties\** — \@ConfigurationProperties\ class bound to \scheduler.newsapi.*\
- **\NewsApiClient\** — added \etchPage()\ for paginated API access + extracted \mapToArticle()\ helper
- **\NewsApiIngestionScheduler\** — \@Scheduled\ job that:
  - Runs at 7 AM daily (configurable cron)
  - Pages through NewsAPI.org up to \max-requests\ times using numeric page index
  - Stops early on partial page (< pageSize) or when totalResults exhausted
  - Skips articles with null/blank URLs
  - Skips duplicate articles via \existsByLink\
  - Logs a run summary (fetched / saved / skipped / errors)
  - Is a no-op when \scheduler.newsapi.enabled: false\
- **Tests**: 13 tests across scheduler (6), properties (2), and client integration (5)
## Test Results
- New tests: **13/13 ✅**
- Build: \mvn clean package -DskipTests\ ✅
Closes #14