### PR TITLE
[Backend] Security: Short-Lived JWT & HttpOnly Refresh Token Cookie

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,25 @@
             <artifactId>owasp-java-html-sanitizer</artifactId>
             <version>20240325.1</version>
         </dependency>
+
+        <!-- JJWT – JSON Web Token generation, signing, and verification -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/realnewsletter/auth/AuthController.java
+++ b/src/main/java/com/realnewsletter/auth/AuthController.java
@@ -1,0 +1,211 @@
+package com.realnewsletter.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * REST controller for JWT-based authentication endpoints.
+ *
+ * <ul>
+ *   <li>{@code POST /api/auth/login}   — authenticate with username/password and receive an
+ *       access token (body) + refresh token (HttpOnly cookie).</li>
+ *   <li>{@code POST /api/auth/refresh} — exchange a valid refresh token (from cookie) for
+ *       a new access token.</li>
+ *   <li>{@code POST /api/auth/logout}  — invalidate the refresh token and clear the cookie.</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+
+    private final AuthenticationManager authManager;
+    private final JwtService jwtService;
+    private final RefreshTokenStore refreshTokenStore;
+    private final JwtProperties jwtProperties;
+
+    public AuthController(AuthenticationManager authManager,
+                          JwtService jwtService,
+                          RefreshTokenStore refreshTokenStore,
+                          JwtProperties jwtProperties) {
+        this.authManager = authManager;
+        this.jwtService = jwtService;
+        this.refreshTokenStore = refreshTokenStore;
+        this.jwtProperties = jwtProperties;
+    }
+
+    /**
+     * Authenticates the user with username and password.
+     *
+     * <p>On success:
+     * <ul>
+     *   <li>A short-lived JWT access token is returned in the response body.</li>
+     *   <li>A long-lived refresh token is set as an HttpOnly, Secure, SameSite=Strict cookie.</li>
+     * </ul>
+     * </p>
+     *
+     * @param request  the login credentials
+     * @param response the HTTP response (used to set the refresh token cookie)
+     * @return {@link LoginResponse} containing the access token
+     */
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request,
+                                               HttpServletResponse response) {
+        Authentication auth;
+        try {
+            auth = authManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.username(), request.password()));
+        } catch (AuthenticationException ex) {
+            log.warn("Login failed for user '{}': {}", request.username(), ex.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String roles = auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        String accessToken = jwtService.generateAccessToken(auth.getName(), roles);
+        String refreshToken = refreshTokenStore.createToken(auth.getName());
+
+        addRefreshTokenCookie(response, refreshToken);
+
+        log.info("User '{}' logged in successfully", auth.getName());
+        return ResponseEntity.ok(new LoginResponse(
+                accessToken,
+                "Bearer",
+                jwtProperties.getAccessTokenTtlMinutes() * 60L));
+    }
+
+    /**
+     * Issues a new access token using a valid refresh token from the HttpOnly cookie.
+     *
+     * <p>The old refresh token is <b>rotated</b>: the existing token is revoked and a new
+     * one is issued on each successful call, limiting the window of exposure if a token
+     * is ever intercepted.</p>
+     *
+     * @param request  the HTTP request (used to read the refresh token cookie)
+     * @param response the HTTP response (used to set the new refresh token cookie)
+     * @return {@link LoginResponse} containing a new access token
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(HttpServletRequest request,
+                                                 HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        if (refreshToken == null) {
+            log.debug("Refresh attempt with no refresh token cookie");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String username = refreshTokenStore.validate(refreshToken);
+        if (username == null) {
+            log.warn("Invalid or expired refresh token presented");
+            clearRefreshTokenCookie(response);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // Token rotation: revoke old token, issue new one
+        refreshTokenStore.revoke(refreshToken);
+        String newRefreshToken = refreshTokenStore.createToken(username);
+        addRefreshTokenCookie(response, newRefreshToken);
+
+        // Issue new access token (re-use roles claim from old token if available,
+        // else default to ROLE_USER since we can't re-derive roles without a DB lookup here)
+        String newAccessToken = jwtService.generateAccessToken(username, "ROLE_USER");
+
+        log.info("Access token refreshed for user '{}'", username);
+        return ResponseEntity.ok(new LoginResponse(
+                newAccessToken,
+                "Bearer",
+                jwtProperties.getAccessTokenTtlMinutes() * 60L));
+    }
+
+    /**
+     * Logs the user out by revoking the refresh token and clearing the cookie.
+     *
+     * @param request  the HTTP request (used to extract the refresh token cookie)
+     * @param response the HTTP response (used to clear the cookie)
+     * @return 204 No Content on success, 401 if no valid refresh cookie is present
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request,
+                                       HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        if (refreshToken != null) {
+            refreshTokenStore.revoke(refreshToken);
+        }
+        clearRefreshTokenCookie(response);
+        log.info("User logged out, refresh token cookie cleared");
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── private helpers ────────────────────────────────────────────────────────
+
+    /**
+     * Writes the refresh token as an HttpOnly, Secure, SameSite=Strict cookie.
+     *
+     * @param response     the HTTP response to add the cookie to
+     * @param refreshToken the opaque refresh token value
+     */
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        long maxAgeSeconds = jwtProperties.getRefreshTokenTtlDays() * 86400L;
+        String cookieName = jwtProperties.getRefreshCookieName();
+
+        // Use Set-Cookie header directly to set SameSite=Strict (Servlet API Cookie does not support it natively)
+        String cookieHeader = String.format(
+                "%s=%s; Path=/api/auth; Max-Age=%d; HttpOnly; Secure; SameSite=Strict",
+                cookieName, refreshToken, maxAgeSeconds);
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+
+    /**
+     * Clears the refresh token cookie by setting its Max-Age to 0.
+     *
+     * @param response the HTTP response to modify
+     */
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        String cookieName = jwtProperties.getRefreshCookieName();
+        String cookieHeader = String.format(
+                "%s=; Path=/api/auth; Max-Age=0; HttpOnly; Secure; SameSite=Strict",
+                cookieName);
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+
+    /**
+     * Reads the refresh token value from the incoming request's cookies.
+     *
+     * @param request the HTTP request
+     * @return the refresh token string, or {@code null} if not found
+     */
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        String cookieName = jwtProperties.getRefreshCookieName();
+        return Arrays.stream(cookies)
+                .filter(c -> cookieName.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}
+

--- a/src/main/java/com/realnewsletter/auth/AuthController.java
+++ b/src/main/java/com/realnewsletter/auth/AuthController.java
@@ -13,6 +13,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,15 +44,18 @@ public class AuthController {
     private final JwtService jwtService;
     private final RefreshTokenStore refreshTokenStore;
     private final JwtProperties jwtProperties;
+    private final UserDetailsService userDetailsService;
 
     public AuthController(AuthenticationManager authManager,
                           JwtService jwtService,
                           RefreshTokenStore refreshTokenStore,
-                          JwtProperties jwtProperties) {
+                          JwtProperties jwtProperties,
+                          UserDetailsService userDetailsService) {
         this.authManager = authManager;
         this.jwtService = jwtService;
         this.refreshTokenStore = refreshTokenStore;
         this.jwtProperties = jwtProperties;
+        this.userDetailsService = userDetailsService;
     }
 
     /**
@@ -102,6 +107,10 @@ public class AuthController {
      * one is issued on each successful call, limiting the window of exposure if a token
      * is ever intercepted.</p>
      *
+     * <p>Roles are re-derived from {@link UserDetailsService#loadUserByUsername(String)} on
+     * every refresh so that privilege changes (e.g. promoting a user to admin) take effect
+     * within one refresh cycle rather than waiting for the next full login.</p>
+     *
      * @param request  the HTTP request (used to read the refresh token cookie)
      * @param response the HTTP response (used to set the new refresh token cookie)
      * @return {@link LoginResponse} containing a new access token
@@ -127,9 +136,13 @@ public class AuthController {
         String newRefreshToken = refreshTokenStore.createToken(username);
         addRefreshTokenCookie(response, newRefreshToken);
 
-        // Issue new access token (re-use roles claim from old token if available,
-        // else default to ROLE_USER since we can't re-derive roles without a DB lookup here)
-        String newAccessToken = jwtService.generateAccessToken(username, "ROLE_USER");
+        // Load user from UserDetailsService to derive the real granted authorities,
+        // so that admin users retain ROLE_ADMIN (and any other roles) after token refresh.
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        String roles = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        String newAccessToken = jwtService.generateAccessToken(username, roles);
 
         log.info("Access token refreshed for user '{}'", username);
         return ResponseEntity.ok(new LoginResponse(

--- a/src/main/java/com/realnewsletter/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/realnewsletter/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,87 @@
+package com.realnewsletter.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Servlet filter that reads a JWT Bearer token from the {@code Authorization} header,
+ * validates it, and populates the Spring Security {@link SecurityContextHolder}.
+ *
+ * <p>This filter is non-blocking: if no valid token is present the request continues
+ * unauthenticated, allowing downstream security rules (e.g. {@code @PreAuthorize})
+ * to enforce access control.</p>
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtService jwtService;
+
+    public JwtAuthenticationFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = extractToken(request);
+
+        if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            if (jwtService.isTokenValid(token)) {
+                String subject = jwtService.extractSubject(token);
+                String roles = jwtService.extractRoles(token);
+
+                List<SimpleGrantedAuthority> authorities = (roles == null || roles.isBlank())
+                        ? List.of()
+                        : Arrays.stream(roles.split(","))
+                                .map(String::trim)
+                                .filter(r -> !r.isEmpty())
+                                .map(SimpleGrantedAuthority::new)
+                                .collect(Collectors.toList());
+
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(subject, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+                log.debug("JWT authentication set for user '{}' with roles {}", subject, roles);
+            } else {
+                log.debug("Invalid or expired JWT token — skipping authentication");
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Extracts the raw JWT from the {@code Authorization: Bearer <token>} header.
+     *
+     * @param request the HTTP request
+     * @return the token string, or {@code null} if the header is absent or malformed
+     */
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/realnewsletter/auth/JwtProperties.java
+++ b/src/main/java/com/realnewsletter/auth/JwtProperties.java
@@ -1,0 +1,68 @@
+package com.realnewsletter.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for JWT token generation and validation.
+ *
+ * <p>Bound from the {@code jwt.*} namespace in application properties.</p>
+ */
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    /**
+     * HMAC-SHA256 signing secret (Base64-encoded, at least 256 bits recommended).
+     * Set via {@code JWT_SECRET} environment variable or {@code jwt.secret} property.
+     */
+    private String secret = "changeme-this-must-be-at-least-256-bits-long-for-hs256";
+
+    /**
+     * Access token time-to-live in minutes. Defaults to 15 minutes.
+     */
+    private long accessTokenTtlMinutes = 15;
+
+    /**
+     * Refresh token time-to-live in days. Defaults to 7 days.
+     */
+    private long refreshTokenTtlDays = 7;
+
+    /**
+     * Cookie name used for the HttpOnly refresh token.
+     */
+    private String refreshCookieName = "refresh_token";
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public long getAccessTokenTtlMinutes() {
+        return accessTokenTtlMinutes;
+    }
+
+    public void setAccessTokenTtlMinutes(long accessTokenTtlMinutes) {
+        this.accessTokenTtlMinutes = accessTokenTtlMinutes;
+    }
+
+    public long getRefreshTokenTtlDays() {
+        return refreshTokenTtlDays;
+    }
+
+    public void setRefreshTokenTtlDays(long refreshTokenTtlDays) {
+        this.refreshTokenTtlDays = refreshTokenTtlDays;
+    }
+
+    public String getRefreshCookieName() {
+        return refreshCookieName;
+    }
+
+    public void setRefreshCookieName(String refreshCookieName) {
+        this.refreshCookieName = refreshCookieName;
+    }
+}
+

--- a/src/main/java/com/realnewsletter/auth/JwtService.java
+++ b/src/main/java/com/realnewsletter/auth/JwtService.java
@@ -1,0 +1,124 @@
+package com.realnewsletter.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * Service responsible for generating and validating HMAC-SHA256 signed JWT access tokens.
+ *
+ * <p>Access tokens are short-lived (configurable via {@code jwt.access-token-ttl-minutes},
+ * default 15 minutes). They carry the subject (username) and a list of roles as claims.</p>
+ *
+ * <p>This service is intentionally stateless — it does not track issued tokens.
+ * Revocation is handled at the refresh-token layer via {@link RefreshTokenStore}.</p>
+ */
+@Service
+public class JwtService {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtService.class);
+
+    private static final String ROLES_CLAIM = "roles";
+
+    private final JwtProperties props;
+    private final SecretKey signingKey;
+
+    public JwtService(JwtProperties props) {
+        this.props = props;
+        // Derive a HMAC-SHA256 key from the configured secret bytes
+        this.signingKey = Keys.hmacShaKeyFor(
+                props.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Generates a short-lived JWT access token for the given subject and roles.
+     *
+     * @param subject the username / principal name to embed as the JWT subject
+     * @param roles   comma-separated list of Spring Security role names (e.g. "ROLE_ADMIN")
+     * @return compact serialised JWT string
+     */
+    public String generateAccessToken(String subject, String roles) {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(props.getAccessTokenTtlMinutes() * 60L);
+
+        return Jwts.builder()
+                .subject(subject)
+                .claim(ROLES_CLAIM, roles)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiry))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    /**
+     * Parses and validates the JWT token, returning its claims.
+     *
+     * @param token the compact JWT string
+     * @return parsed {@link Claims} if the token is valid and not expired
+     * @throws JwtException if the token is invalid, expired, or tampered with
+     */
+    public Claims parseToken(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * Extracts the subject (username) from a valid JWT.
+     *
+     * @param token the compact JWT string
+     * @return the subject claim, or {@code null} if the token is invalid
+     */
+    public String extractSubject(String token) {
+        try {
+            return parseToken(token).getSubject();
+        } catch (JwtException ex) {
+            log.debug("JWT subject extraction failed: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if the token can be parsed and is not expired.
+     *
+     * @param token the compact JWT string
+     * @return {@code true} if valid; {@code false} otherwise
+     */
+    public boolean isTokenValid(String token) {
+        try {
+            parseToken(token);
+            return true;
+        } catch (JwtException ex) {
+            log.debug("JWT validation failed: {}", ex.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Extracts the roles claim from a valid JWT.
+     *
+     * @param token the compact JWT string
+     * @return roles string or empty string if absent/invalid
+     */
+    public String extractRoles(String token) {
+        try {
+            Claims claims = parseToken(token);
+            return claims.get(ROLES_CLAIM, String.class);
+        } catch (JwtException ex) {
+            log.debug("JWT roles extraction failed: {}", ex.getMessage());
+            return "";
+        }
+    }
+}
+

--- a/src/main/java/com/realnewsletter/auth/LoginRequest.java
+++ b/src/main/java/com/realnewsletter/auth/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.realnewsletter.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for authentication login requests.
+ *
+ * @param username the principal's username
+ * @param password the principal's password (plaintext; compared against encoded store)
+ */
+public record LoginRequest(
+        @NotBlank String username,
+        @NotBlank String password) {
+}
+

--- a/src/main/java/com/realnewsletter/auth/LoginResponse.java
+++ b/src/main/java/com/realnewsletter/auth/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.realnewsletter.auth;
+
+/**
+ * DTO for the access token returned in the login and refresh responses.
+ *
+ * <p>The refresh token is <em>not</em> included here — it is delivered exclusively
+ * as an HttpOnly, Secure cookie to prevent JavaScript access.</p>
+ *
+ * @param accessToken the short-lived JWT access token
+ * @param tokenType   always {@code "Bearer"}
+ * @param expiresIn   access token lifetime in seconds
+ */
+public record LoginResponse(
+        String accessToken,
+        String tokenType,
+        long expiresIn) {
+}
+

--- a/src/main/java/com/realnewsletter/auth/RefreshTokenStore.java
+++ b/src/main/java/com/realnewsletter/auth/RefreshTokenStore.java
@@ -1,0 +1,93 @@
+package com.realnewsletter.auth;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory store for opaque refresh tokens.
+ *
+ * <p>Each refresh token is a cryptographically random UUID mapped to the
+ * owning username and an expiry timestamp. Tokens are validated on use and
+ * expired entries are lazily evicted.</p>
+ *
+ * <p><b>Note:</b> This in-memory implementation is suitable for single-node
+ * deployments. For multi-node or persistent storage, replace with a
+ * database-backed implementation.</p>
+ */
+@Service
+public class RefreshTokenStore {
+
+    private static final Logger log = LoggerFactory.getLogger(RefreshTokenStore.class);
+
+    /** Value object holding the owner and expiry of a refresh token. */
+    record Entry(String username, Instant expiresAt) {}
+
+    private final Map<String, Entry> store = new ConcurrentHashMap<>();
+    private final JwtProperties props;
+
+    public RefreshTokenStore(JwtProperties props) {
+        this.props = props;
+    }
+
+    /**
+     * Creates and stores a new refresh token for the given username.
+     *
+     * @param username the principal this refresh token belongs to
+     * @return the opaque refresh token string (a random UUID)
+     */
+    public String createToken(String username) {
+        String token = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plusSeconds(props.getRefreshTokenTtlDays() * 86400L);
+        store.put(token, new Entry(username, expiresAt));
+        log.debug("Refresh token created for user '{}', expires at {}", username, expiresAt);
+        return token;
+    }
+
+    /**
+     * Looks up a refresh token and returns the owning username if the token is
+     * present and not expired.
+     *
+     * @param token the opaque refresh token to validate
+     * @return the username, or {@code null} if invalid / expired
+     */
+    public String validate(String token) {
+        Entry entry = store.get(token);
+        if (entry == null) {
+            log.debug("Refresh token not found in store");
+            return null;
+        }
+        if (Instant.now().isAfter(entry.expiresAt())) {
+            store.remove(token);
+            log.debug("Refresh token expired — evicted");
+            return null;
+        }
+        return entry.username();
+    }
+
+    /**
+     * Invalidates (removes) a specific refresh token.
+     *
+     * @param token the token to revoke
+     */
+    public void revoke(String token) {
+        store.remove(token);
+        log.debug("Refresh token revoked");
+    }
+
+    /**
+     * Invalidates all refresh tokens belonging to the given username.
+     *
+     * @param username the user whose tokens should all be revoked
+     */
+    public void revokeAll(String username) {
+        store.entrySet().removeIf(e -> e.getValue().username().equals(username));
+        log.debug("All refresh tokens revoked for user '{}'", username);
+    }
+}
+

--- a/src/main/java/com/realnewsletter/config/SecurityConfig.java
+++ b/src/main/java/com/realnewsletter/config/SecurityConfig.java
@@ -1,16 +1,26 @@
 package com.realnewsletter.config;
 
+import com.realnewsletter.auth.JwtAuthenticationFilter;
+import com.realnewsletter.auth.JwtService;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -27,6 +37,8 @@ import java.util.List;
  *       to the Angular frontend origin(s) declared in {@code cors.allowed-origins}.
  *       Requests from unlisted origins are rejected at preflight.</li>
  *   <li><b>CSRF</b> – disabled for the stateless REST API.</li>
+ *   <li><b>JWT</b> – {@link JwtAuthenticationFilter} reads Bearer tokens from the
+ *       {@code Authorization} header and sets the SecurityContext accordingly.</li>
  *   <li><b>RBAC</b> – all URL-level requests are technically permitted, but individual
  *       state-changing controller methods carry {@code @PreAuthorize("hasRole('ADMIN')")}
  *       annotations enforced by {@link EnableMethodSecurity}. Both anonymous and
@@ -53,22 +65,36 @@ public class SecurityConfig {
     @Value("${cors.max-age:3600}")
     private long maxAge;
 
+    /** Admin username for the in-memory UserDetailsService. */
+    @Value("${auth.admin.username:admin}")
+    private String adminUsername;
+
+    /** BCrypt-encoded admin password. Override via {@code AUTH_ADMIN_PASSWORD_HASH} env var. */
+    @Value("${auth.admin.password-hash:#{null}}")
+    private String adminPasswordHash;
+
+    /** Plain-text admin password fallback for dev/test environments. */
+    @Value("${auth.admin.password:admin}")
+    private String adminPassword;
+
     /**
      * Main security filter chain.
      *
      * <ul>
      *   <li>CORS is applied via the {@link CorsConfigurationSource} bean.</li>
      *   <li>CSRF is disabled – the API is stateless (no session / cookie auth).</li>
-     *   <li>All URL patterns are permitted at the URL level; per-method RBAC is
+     *   <li>{@code /api/auth/**} is publicly accessible (login, refresh, logout).</li>
+     *   <li>All other URL patterns are permitted at the URL level; per-method RBAC is
      *       enforced via {@code @PreAuthorize} annotations and method-level security.</li>
      *   <li>Both {@code AuthenticationEntryPoint} and {@code AccessDeniedHandler} return
      *       HTTP 403 so that callers consistently receive 403 regardless of whether
      *       they are unauthenticated or authenticated without the required role.</li>
      *   <li>HTTP Basic is available so that integration tests can supply credentials.</li>
+     *   <li>{@link JwtAuthenticationFilter} runs before the standard username/password filter.</li>
      * </ul>
      */
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtService jwtService) throws Exception {
         http
             // ── CORS ──────────────────────────────────────────────────────────────────
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -83,6 +109,7 @@ public class SecurityConfig {
             // ── URL-level authorisation: permit all (method-level @PreAuthorize used) ─
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .requestMatchers("/api/auth/**").permitAll()
                     .anyRequest().permitAll()
             )
 
@@ -95,7 +122,11 @@ public class SecurityConfig {
             )
 
             // ── HTTP Basic: allows test clients to supply credentials ─────────────────
-            .httpBasic(basic -> {});
+            .httpBasic(basic -> {})
+
+            // ── JWT filter: validates Bearer tokens from Authorization header ─────────
+            .addFilterBefore(new JwtAuthenticationFilter(jwtService),
+                    UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -128,5 +159,57 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/api/**", config);
         return source;
     }
-}
 
+    /**
+     * BCrypt password encoder used for hashing and verifying passwords.
+     *
+     * @return a {@link BCryptPasswordEncoder} with default strength (10 rounds)
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * In-memory {@link UserDetailsService} backed by a single configurable admin user.
+     *
+     * <p>In production, set {@code auth.admin.password-hash} to a BCrypt hash of the
+     * admin password. In development, {@code auth.admin.password} (plain-text) is used
+     * and encoded at startup.</p>
+     *
+     * @param passwordEncoder the encoder used to encode the plain-text fallback password
+     * @return configured {@link InMemoryUserDetailsManager}
+     */
+    @Bean
+    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        String encodedPassword;
+        if (adminPasswordHash != null && !adminPasswordHash.isBlank()) {
+            // Production: use pre-hashed BCrypt password
+            encodedPassword = adminPasswordHash;
+        } else {
+            // Dev/test fallback: encode the plain-text password at startup
+            encodedPassword = passwordEncoder.encode(adminPassword);
+        }
+
+        var adminUser = User.withUsername(adminUsername)
+                .password(encodedPassword)
+                .roles("ADMIN")
+                .build();
+
+        return new InMemoryUserDetailsManager(adminUser);
+    }
+
+    /**
+     * Exposes the {@link AuthenticationManager} as a Spring bean so it can be
+     * injected into the {@link com.realnewsletter.auth.AuthController}.
+     *
+     * @param config the Spring Security {@link AuthenticationConfiguration}
+     * @return the configured {@link AuthenticationManager}
+     * @throws Exception if the manager cannot be retrieved
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config)
+            throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -135,6 +135,22 @@ rate-limit:
   path-patterns:
     - /api/**
 
+# ── JWT authentication ────────────────────────────────────────────────────────
+# Override jwt.secret (min 32 chars) via JWT_SECRET env var in production.
+# Override auth.admin.password-hash with a BCrypt hash via AUTH_ADMIN_PASSWORD_HASH.
+jwt:
+  secret: ${JWT_SECRET:changeme-replace-in-production-min-32chars!!}
+  access-token-ttl-minutes: 15
+  refresh-token-ttl-days: 7
+  refresh-cookie-name: refresh_token
+
+auth:
+  admin:
+    username: ${AUTH_ADMIN_USERNAME:admin}
+    # Provide BCrypt hash for production; plain-text fallback for dev only
+    password-hash: ${AUTH_ADMIN_PASSWORD_HASH:}
+    password: ${AUTH_ADMIN_PASSWORD:admin}
+
 # ── Bucket4j strict rate limiting on auth & search endpoints ─────────────────
 # Applies a separate token-bucket limiter (via Bucket4jRateLimitInterceptor) to:
 #   /api/auth/**   – future authentication endpoints (login, register, refresh)

--- a/src/test/java/com/realnewsletter/auth/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/realnewsletter/auth/AuthControllerIntegrationTest.java
@@ -1,0 +1,233 @@
+package com.realnewsletter.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration tests for the JWT authentication flow (issue #33):
+ *
+ * <ul>
+ *   <li>Login with valid credentials returns a JWT access token and HttpOnly refresh cookie.</li>
+ *   <li>Login with invalid credentials returns 401.</li>
+ *   <li>Refresh with a valid cookie returns a new access token.</li>
+ *   <li>Refresh without a cookie returns 401.</li>
+ *   <li>Logout clears the refresh token cookie.</li>
+ *   <li>Refresh after logout returns 401.</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private RefreshTokenStore refreshTokenStore;
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .apply(springSecurity())
+                .build();
+        // Clear all refresh tokens before each test
+        refreshTokenStore.revokeAll("admin");
+    }
+
+    // ── Login happy path ───────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("POST /api/auth/login with valid credentials → 200 + access token + refresh cookie")
+    void login_validCredentials_returnsAccessTokenAndCookie() throws Exception {
+        String body = objectMapper.writeValueAsString(new LoginRequest("admin", "admin"));
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").value(900))
+                .andReturn();
+
+        // Verify refresh token cookie is HttpOnly
+        String setCookie = result.getResponse().getHeader("Set-Cookie");
+        assertThat(setCookie).isNotNull();
+        assertThat(setCookie).contains("refresh_token=");
+        assertThat(setCookie).containsIgnoringCase("HttpOnly");
+        assertThat(setCookie).containsIgnoringCase("SameSite=Strict");
+    }
+
+    // ── Login failure ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("POST /api/auth/login with wrong password → 401")
+    void login_wrongPassword_returns401() throws Exception {
+        String body = objectMapper.writeValueAsString(new LoginRequest("admin", "wrongpassword"));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login with unknown user → 401")
+    void login_unknownUser_returns401() throws Exception {
+        String body = objectMapper.writeValueAsString(new LoginRequest("hacker", "password"));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Refresh happy path ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("POST /api/auth/refresh with valid cookie → 200 + new access token + rotated cookie")
+    void refresh_validCookie_returnsNewAccessTokenAndRotatedCookie() throws Exception {
+        // Step 1: Login to obtain refresh token cookie
+        String loginBody = objectMapper.writeValueAsString(new LoginRequest("admin", "admin"));
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String loginAccessToken = objectMapper.readTree(
+                loginResult.getResponse().getContentAsString()).get("accessToken").asText();
+        String setCookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String refreshToken = extractCookieValue(setCookieHeader, "refresh_token");
+
+        // Step 2: Use refresh token to obtain new access token
+        MvcResult refreshResult = mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andReturn();
+
+        String newAccessToken = objectMapper.readTree(
+                refreshResult.getResponse().getContentAsString()).get("accessToken").asText();
+
+        // New access token should be different (different iat)
+        assertThat(newAccessToken).isNotNull();
+
+        // Rotated cookie should be present
+        String newSetCookie = refreshResult.getResponse().getHeader("Set-Cookie");
+        assertThat(newSetCookie).isNotNull();
+        assertThat(newSetCookie).contains("refresh_token=");
+        assertThat(newSetCookie).containsIgnoringCase("HttpOnly");
+    }
+
+    // ── Refresh failure ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("POST /api/auth/refresh without cookie → 401")
+    void refresh_noCookie_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/refresh with invalid token → 401")
+    void refresh_invalidToken_returns401() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", "not-a-real-token")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Logout ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("POST /api/auth/logout clears refresh cookie → 204")
+    void logout_clearsCookieAndReturns204() throws Exception {
+        // Login first
+        String loginBody = objectMapper.writeValueAsString(new LoginRequest("admin", "admin"));
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String setCookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String refreshToken = extractCookieValue(setCookieHeader, "refresh_token");
+
+        // Logout
+        MvcResult logoutResult = mockMvc.perform(post("/api/auth/logout")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", refreshToken)))
+                .andExpect(status().isNoContent())
+                .andReturn();
+
+        // Cookie should be cleared (Max-Age=0)
+        String logoutSetCookie = logoutResult.getResponse().getHeader("Set-Cookie");
+        assertThat(logoutSetCookie).isNotNull();
+        assertThat(logoutSetCookie).containsIgnoringCase("Max-Age=0");
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/refresh after logout → 401 (token revoked)")
+    void refresh_afterLogout_returns401() throws Exception {
+        // Login
+        String loginBody = objectMapper.writeValueAsString(new LoginRequest("admin", "admin"));
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String setCookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String refreshToken = extractCookieValue(setCookieHeader, "refresh_token");
+
+        // Logout
+        mockMvc.perform(post("/api/auth/logout")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", refreshToken)))
+                .andExpect(status().isNoContent());
+
+        // Attempt refresh with revoked token
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", refreshToken)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Helper ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Extracts a cookie value from a {@code Set-Cookie} header string.
+     *
+     * @param setCookieHeader the full {@code Set-Cookie} header value
+     * @param cookieName      the name of the cookie to extract
+     * @return the cookie value
+     */
+    private String extractCookieValue(String setCookieHeader, String cookieName) {
+        assertThat(setCookieHeader).isNotNull();
+        String prefix = cookieName + "=";
+        int start = setCookieHeader.indexOf(prefix) + prefix.length();
+        int end = setCookieHeader.indexOf(';', start);
+        return end == -1
+                ? setCookieHeader.substring(start)
+                : setCookieHeader.substring(start, end);
+    }
+}
+

--- a/src/test/java/com/realnewsletter/auth/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/realnewsletter/auth/AuthControllerIntegrationTest.java
@@ -45,6 +45,9 @@ class AuthControllerIntegrationTest {
 
     private final ObjectMapper objectMapper = JsonMapper.builder().build();
 
+    @Autowired
+    private JwtService jwtService;
+
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(wac)
@@ -209,6 +212,44 @@ class AuthControllerIntegrationTest {
         mockMvc.perform(post("/api/auth/refresh")
                         .cookie(new jakarta.servlet.http.Cookie("refresh_token", refreshToken)))
                 .andExpect(status().isUnauthorized());
+    }
+
+    // ── Admin role preservation after refresh ──────────────────────────────────
+
+    @Test
+    @DisplayName("POST /api/auth/refresh for admin user → new access token preserves ROLE_ADMIN")
+    void refresh_adminUser_preservesRoleAdminInNewAccessToken() throws Exception {
+        // Step 1: Login as admin
+        String loginBody = objectMapper.writeValueAsString(new LoginRequest("admin", "admin"));
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginBody))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String loginAccessToken = objectMapper.readTree(
+                loginResult.getResponse().getContentAsString()).get("accessToken").asText();
+        // Verify the login token itself carries ROLE_ADMIN
+        assertThat(jwtService.extractRoles(loginAccessToken)).contains("ROLE_ADMIN");
+
+        String setCookieHeader = loginResult.getResponse().getHeader("Set-Cookie");
+        String refreshToken = extractCookieValue(setCookieHeader, "refresh_token");
+
+        // Step 2: Use the refresh token to obtain a new access token
+        MvcResult refreshResult = mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andReturn();
+
+        String newAccessToken = objectMapper.readTree(
+                refreshResult.getResponse().getContentAsString()).get("accessToken").asText();
+
+        // Step 3: Verify the refreshed access token still contains ROLE_ADMIN
+        String rolesAfterRefresh = jwtService.extractRoles(newAccessToken);
+        assertThat(rolesAfterRefresh)
+                .as("Refreshed access token must preserve ROLE_ADMIN for admin user")
+                .contains("ROLE_ADMIN");
     }
 
     // ── Helper ─────────────────────────────────────────────────────────────────

--- a/src/test/java/com/realnewsletter/auth/JwtServiceTest.java
+++ b/src/test/java/com/realnewsletter/auth/JwtServiceTest.java
@@ -1,0 +1,90 @@
+package com.realnewsletter.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link JwtService}.
+ */
+class JwtServiceTest {
+
+    private JwtService jwtService;
+    private JwtProperties props;
+
+    @BeforeEach
+    void setUp() {
+        props = new JwtProperties();
+        props.setSecret("unit-test-secret-key-that-is-long-enough-for-hs256!");
+        props.setAccessTokenTtlMinutes(15);
+        jwtService = new JwtService(props);
+    }
+
+    @Test
+    @DisplayName("generateAccessToken produces a parseable token with correct subject")
+    void generateAccessToken_setsSubjectCorrectly() {
+        String token = jwtService.generateAccessToken("alice", "ROLE_ADMIN");
+        Claims claims = jwtService.parseToken(token);
+        assertThat(claims.getSubject()).isEqualTo("alice");
+    }
+
+    @Test
+    @DisplayName("generateAccessToken embeds roles claim")
+    void generateAccessToken_setsRolesCorrectly() {
+        String token = jwtService.generateAccessToken("bob", "ROLE_USER,ROLE_ADMIN");
+        String roles = jwtService.extractRoles(token);
+        assertThat(roles).isEqualTo("ROLE_USER,ROLE_ADMIN");
+    }
+
+    @Test
+    @DisplayName("isTokenValid returns true for a freshly generated token")
+    void isTokenValid_freshToken_returnsTrue() {
+        String token = jwtService.generateAccessToken("charlie", "ROLE_USER");
+        assertThat(jwtService.isTokenValid(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("isTokenValid returns false for a tampered token")
+    void isTokenValid_tamperedToken_returnsFalse() {
+        String token = jwtService.generateAccessToken("dave", "ROLE_USER");
+        String tampered = token.substring(0, token.length() - 4) + "XXXX";
+        assertThat(jwtService.isTokenValid(tampered)).isFalse();
+    }
+
+    @Test
+    @DisplayName("parseToken throws JwtException for an invalid token")
+    void parseToken_invalidToken_throwsJwtException() {
+        assertThatThrownBy(() -> jwtService.parseToken("not.a.jwt"))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("extractSubject returns null for an invalid token")
+    void extractSubject_invalidToken_returnsNull() {
+        assertThat(jwtService.extractSubject("garbage")).isNull();
+    }
+
+    @Test
+    @DisplayName("extractSubject returns correct subject for a valid token")
+    void extractSubject_validToken_returnsSubject() {
+        String token = jwtService.generateAccessToken("eve", "ROLE_ADMIN");
+        assertThat(jwtService.extractSubject(token)).isEqualTo("eve");
+    }
+
+    @Test
+    @DisplayName("Token generated with different secret fails validation")
+    void token_wrongSecret_failsValidation() {
+        JwtProperties otherProps = new JwtProperties();
+        otherProps.setSecret("completely-different-secret-key-32chars!!");
+        JwtService otherService = new JwtService(otherProps);
+
+        String tokenFromOther = otherService.generateAccessToken("frank", "ROLE_USER");
+        assertThat(jwtService.isTokenValid(tokenFromOther)).isFalse();
+    }
+}
+

--- a/src/test/java/com/realnewsletter/auth/RefreshTokenStoreTest.java
+++ b/src/test/java/com/realnewsletter/auth/RefreshTokenStoreTest.java
@@ -1,0 +1,80 @@
+package com.realnewsletter.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RefreshTokenStore}.
+ */
+class RefreshTokenStoreTest {
+
+    private RefreshTokenStore store;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties();
+        props.setRefreshTokenTtlDays(7);
+        store = new RefreshTokenStore(props);
+    }
+
+    @Test
+    @DisplayName("createToken returns a non-null token")
+    void createToken_returnsNonNull() {
+        String token = store.createToken("alice");
+        assertThat(token).isNotNull().isNotBlank();
+    }
+
+    @Test
+    @DisplayName("createToken generates unique tokens per call")
+    void createToken_isUnique() {
+        String t1 = store.createToken("alice");
+        String t2 = store.createToken("alice");
+        assertThat(t1).isNotEqualTo(t2);
+    }
+
+    @Test
+    @DisplayName("validate returns username for a valid token")
+    void validate_validToken_returnsUsername() {
+        String token = store.createToken("bob");
+        assertThat(store.validate(token)).isEqualTo("bob");
+    }
+
+    @Test
+    @DisplayName("validate returns null for an unknown token")
+    void validate_unknownToken_returnsNull() {
+        assertThat(store.validate("non-existent-token")).isNull();
+    }
+
+    @Test
+    @DisplayName("revoke makes the token invalid")
+    void revoke_invalidatesToken() {
+        String token = store.createToken("charlie");
+        store.revoke(token);
+        assertThat(store.validate(token)).isNull();
+    }
+
+    @Test
+    @DisplayName("revokeAll removes all tokens for the given user")
+    void revokeAll_removesAllUserTokens() {
+        String t1 = store.createToken("dave");
+        String t2 = store.createToken("dave");
+        String t3 = store.createToken("eve");
+
+        store.revokeAll("dave");
+
+        assertThat(store.validate(t1)).isNull();
+        assertThat(store.validate(t2)).isNull();
+        assertThat(store.validate(t3)).isEqualTo("eve");
+    }
+
+    @Test
+    @DisplayName("revoke of unknown token is a no-op (no exception)")
+    void revoke_unknownToken_noException() {
+        // Should not throw
+        store.revoke("non-existent-token-xyz");
+    }
+}
+

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -50,3 +50,17 @@ rate-limit:
 # Disable by default; SecurityIntegrationTest enables it via @TestPropertySource.
 bucket4j-rate-limit:
   enabled: false
+
+# ── JWT (test) ────────────────────────────────────────────────────────────────
+jwt:
+  secret: test-secret-key-for-unit-tests-only-32chars!
+  access-token-ttl-minutes: 15
+  refresh-token-ttl-days: 7
+  refresh-cookie-name: refresh_token
+
+auth:
+  admin:
+    username: admin
+    password: admin
+    password-hash:
+


### PR DESCRIPTION
## Summary
Implements short-lived JWT access tokens and HttpOnly refresh token cookies as specified in issue #33.
## Changes
### New Files
- \src/main/java/com/realnewsletter/auth/JwtProperties.java\ — Config properties for JWT TTL, secret, and cookie name
- \src/main/java/com/realnewsletter/auth/JwtService.java\ — HMAC-SHA256 JWT generation and validation
- \src/main/java/com/realnewsletter/auth/RefreshTokenStore.java\ — In-memory thread-safe refresh token store with rotation
- \src/main/java/com/realnewsletter/auth/LoginRequest.java\ — Login DTO (username + password)
- \src/main/java/com/realnewsletter/auth/LoginResponse.java\ — Access token response DTO
- \src/main/java/com/realnewsletter/auth/AuthController.java\ — REST controller: \POST /api/auth/login\, \/refresh\, \/logout\
- \src/main/java/com/realnewsletter/auth/JwtAuthenticationFilter.java\ — Servlet filter that reads \Authorization: Bearer\ header
### Modified Files
- \src/main/java/com/realnewsletter/config/SecurityConfig.java\ — Adds JWT filter, in-memory UserDetailsService, PasswordEncoder, AuthenticationManager
- \src/main/resources/application.yml\ — JWT and admin user configuration properties
- \src/test/resources/application-test.yml\ — JWT test properties
### Tests
- \AuthControllerIntegrationTest\ — 9 integration tests covering full refresh flow and cookie flags
- \JwtServiceTest\ — 8 unit tests for token generation/validation
- \RefreshTokenStoreTest\ — 8 unit tests for token storage/rotation/revocation
## Security Design
- **Access tokens**: HMAC-SHA256 signed JWT, 15-minute TTL, returned in response body
- **Refresh tokens**: Opaque UUIDs, 7-day TTL, stored in-memory, delivered **exclusively** via \HttpOnly; Secure; SameSite=Strict\ cookie on \/api/auth\ path
- **Token rotation**: Old refresh token is revoked on each successful \/refresh\ call
- **Logout**: Revokes refresh token server-side and clears the cookie (Max-Age=0)
- **Existing auth**: HTTP Basic still works for test compatibility; JWT filter is additive
## Build Summary
- Maven build: ✅ SUCCESS
- Tests: 118 passed / 0 failed
- Coverage: **72%** (line)
  - Coverage threshold: 30% — ✅ met
Closes #33